### PR TITLE
feat: 알림 페이지 초안 구현

### DIFF
--- a/app/notification/components/Tab.tsx
+++ b/app/notification/components/Tab.tsx
@@ -1,0 +1,41 @@
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import NotiTabList from "./TabList";
+
+export default function Tab() {
+  return (
+    <Tabs defaultValue="share" className="w-full">
+      <TabsList>
+        <TabsTrigger value="share">나눔</TabsTrigger>
+        <TabsTrigger value="together">같이 장보기</TabsTrigger>
+      </TabsList>
+      <TabsContent value="share">
+        <NotiTabList
+          type="share"
+          time={1}
+          nickname="하랑"
+          title="프론트엔드 노트북 나눔"
+        />
+        <NotiTabList
+          type="end"
+          time={2}
+          nickname="하랑"
+          title="프론트엔드 노트북 나눔"
+        />
+        <NotiTabList
+          type="review"
+          time={3}
+          nickname="하랑"
+          title="프론트엔드 노트북 나눔"
+        />
+      </TabsContent>
+      <TabsContent value="together">
+        <NotiTabList
+          type="together"
+          time={1}
+          nickname="하랑"
+          title="프론트엔드 노트북 나눔"
+        />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/app/notification/components/TabList.tsx
+++ b/app/notification/components/TabList.tsx
@@ -1,0 +1,71 @@
+import { Handshake, ClockAlert, SmilePlus, ShoppingCart } from "lucide-react";
+
+interface NotiTabListProps {
+  type: "share" | "end" | "review" | "together";
+  time: number;
+  nickname: string;
+  title: string;
+}
+
+export default function NotiTabList({
+  type,
+  time,
+  nickname,
+  title,
+}: NotiTabListProps) {
+  return (
+    <div className="px-4 py-5 border w-full h-[110px]">
+      <div className="flex flex-col">
+        <div className="flex items-center flex-row justify-between">
+          {type === "share" && (
+            <div className="flex flex-row gap-2 text-primary">
+              <Handshake />
+              <p className="badge-bold">나눔 신청</p>
+            </div>
+          )}
+          {type === "end" && (
+            <div className="flex flex-row gap-2 text-(--warning)">
+              <ClockAlert />
+              <p className="badge-bold">나눔 기한 만료</p>
+            </div>
+          )}
+          {type === "review" && (
+            <div className="flex flex-row gap-2 text-(--orange)">
+              <SmilePlus />
+              <p className="badge-bold">같이 장보기 신청</p>
+            </div>
+          )}
+
+          {type === "together" && (
+            <div className="flex flex-row gap-2 text-(--secondary)">
+              <ShoppingCart />
+              <p className="badge-bold">나눔 후기</p>
+            </div>
+          )}
+          <p className="text-zinc-400 badge-bold">{time}시간 전</p>
+        </div>
+
+        {type === "share" && (
+          <div className="body-md !font-bold pl-8 w-full h-auto break-words">
+            {nickname} 님으로부터 “{title}” 나눔 신청이 왔어요
+          </div>
+        )}
+        {type === "end" && (
+          <div className="body-md !font-bold pl-8 w-full h-auto break-words">
+            나눔글이 만료되었어요!
+          </div>
+        )}
+        {type === "review" && (
+          <div className="body-md !font-bold pl-8 w-full h-auto break-words">
+            {nickname} 님이 보낸 “{title}” 나눔 후기가 도착했어요
+          </div>
+        )}
+        {type === "together" && (
+          <div className="body-md !font-bold pl-8 w-full h-auto break-words">
+            {nickname} 님이 “{title}” 같이 장보기에 참여했어요
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/notification/page.tsx
+++ b/app/notification/page.tsx
@@ -1,0 +1,5 @@
+import Tab from "./components/Tab";
+
+export default function Notification() {
+  return <Tab />;
+}

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -4,26 +4,33 @@ import Image from "next/image";
 import Link from "next/link";
 
 export default function Header() {
-	return (
-		<header className="z-10 sticky top-0 flex justify-between items-center bg-white min-h-[var(--h-header)] px-4 py-2">
-			<Link href="/">
-				<Image src="/assets/logo.png" alt="logo" width={55} height={36} />
-			</Link>
+  const isNotification = false;
 
-			{/* <Image
-				src="/assets/images/lucide/bell.svg"
-				width={24}
-				height={24}
-				alt="알람 없을 때 아이콘"
-				className="cursor-pointer"
-			/> */}
-			<Image
-				src="/assets/images/lucide/bell-dot.svg"
-				width={24}
-				height={24}
-				alt="알람 있을 때 아이콘"
-				className="cursor-pointer"
-			/>
-		</header>
-	);
+  return (
+    <header className="z-10 sticky top-0 flex justify-between items-center bg-white min-h-[var(--h-header)] px-4 py-2">
+      <Link href="/">
+        <Image src="/assets/logo.png" alt="logo" width={55} height={36} />
+      </Link>
+
+      <Link href="/notification">
+        {isNotification ? (
+          <Image
+            src="/assets/images/lucide/bell-dot.svg"
+            width={24}
+            height={24}
+            alt="알람 있을 때 아이콘"
+            className="cursor-pointer"
+          />
+        ) : (
+          <Image
+            src="/assets/images/lucide/bell.svg"
+            width={24}
+            height={24}
+            alt="알람 없을 때 아이콘"
+            className="cursor-pointer"
+          />
+        )}
+      </Link>
+    </header>
+  );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,8 @@ module.exports = {
     extend: {
       colors: {
         primary: "var(--primary)",
+        warning: "var(--warning)",
+        orange: "var(--orange)",
       },
     },
   },


### PR DESCRIPTION
## 📌 이슈 번호
close #50 
## ✨ 작업 내용

- 알림 페이지 초안을 구현했습니다.
- 기존 Header에서 알림이 있을때만 아이콘이 바뀌도록 수정했습니다.
- 탭에 따라서 props로   type, time, nickname, title 을 받아와서 NotiTabList를 사용할 수 있습니다.

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)
<img width="431" alt="스크린샷 2025-05-14 오후 4 06 35" src="https://github.com/user-attachments/assets/dbf6fa8d-9a94-49e1-b11a-fa40e9cf2de4" />

## 💬 기타 참고 사항
