### PR TITLE
FormInput 컴포넌트 추가

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -1,12 +1,26 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { Form } from "@/components/ui/form";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 
 import AddButton from "@/components/common/AddButton";
-import { Input } from "@/components/ui/input";
 import InputCalendar from "@/components/common/InputCalendar";
 import { ListCard } from "@/components/common/ListCard";
+import FormInput from "@/components/common/FormInput";
 
 export default function Home() {
+  const form = useForm({
+    defaultValues: {
+      email: "",
+    },
+  });
+
+  const onSubmit = (data: any) => {
+    console.log(data);
+  };
+
   const data = [
     {
       thumbnailSrc: "/assets/images/example/thumbnail.png",
@@ -26,16 +40,12 @@ export default function Home() {
       timeLeft: "21시간 남음",
       location: "서울대입구역 롯데시네마",
     },
-
-    // 뱃지 없는 케이스
     {
       thumbnailSrc: "/assets/images/example/thumbnail.png",
       title: "양파 나눔해요요...",
       timeLeft: "21시간 남음",
       location: "서울대입구역 롯데시네마",
     },
-
-    // 시간 없는 케이스
     {
       thumbnailSrc: "/assets/images/example/thumbnail.png",
       title: "양파 나눔해요요...",
@@ -86,7 +96,18 @@ export default function Home() {
       <br />
 
       <h3>Input</h3>
-      <Input placeholder="ex. 양파 나눔해요" />
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <p>form 양식은 따로 만드세요</p>
+          <FormInput
+            name="email"
+            label="이메일"
+            placeholder="이메일을 입력하세요"
+            type="email"
+          />
+          <button type="submit">임시 제출 버튼</button>
+        </form>
+      </Form>
 
       <br />
       <br />

--- a/components/common/FormInput.tsx
+++ b/components/common/FormInput.tsx
@@ -1,0 +1,53 @@
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+interface FormInputProps {
+  name: string;
+  label?: string;
+  placeholder?: string;
+  type?: string;
+  description?: string;
+  className?: string;
+  inputClassName?: string;
+  disabled?: boolean;
+}
+
+export default function FormInput({
+  name,
+  label,
+  placeholder,
+  type = "text",
+  description,
+  className,
+  inputClassName,
+  disabled,
+}: FormInputProps) {
+  return (
+    <FormField
+      name={name}
+      render={({ field }) => (
+        <FormItem className={className}>
+          {label && <FormLabel>{label}</FormLabel>}
+          <FormControl>
+            <Input
+              className={inputClassName}
+              type={type}
+              placeholder={placeholder}
+              disabled={disabled}
+              {...field}
+            />
+          </FormControl>
+          <FormMessage />
+          {description && <FormDescription>{description}</FormDescription>}
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : props.children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-destructive text-sm", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sik-share",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.0.1",
         "@lottiefiles/dotlottie-react": "^0.13.5",
         "@prisma/client": "^6.7.0",
         "@radix-ui/react-dialog": "^1.1.13",
@@ -32,11 +33,13 @@
         "react": "^19.0.0",
         "react-datepicker": "^8.3.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.56.3",
         "shadcn": "^2.5.0",
         "swiper": "^11.2.6",
         "tailwind-merge": "^3.2.0",
         "three": "^0.176.0",
         "vaul": "^1.1.2",
+        "zod": "^3.24.4",
         "zustand": "^5.0.4"
       },
       "devDependencies": {
@@ -1345,6 +1348,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
+      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -3077,6 +3092,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -8745,6 +8766,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.56.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.3.tgz",
+      "integrity": "sha512-IK18V6GVbab4TAo1/cz3kqajxbDPGofdF0w7VHdCo0Nt8PrPlOZcuuDq9YYIV1BtjcX78x0XsldbQRQnQXWXmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "seed": "npx tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.0.1",
     "@lottiefiles/dotlottie-react": "^0.13.5",
     "@prisma/client": "^6.7.0",
     "@radix-ui/react-dialog": "^1.1.13",
@@ -37,11 +38,13 @@
     "react": "^19.0.0",
     "react-datepicker": "^8.3.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.56.3",
     "shadcn": "^2.5.0",
     "swiper": "^11.2.6",
     "tailwind-merge": "^3.2.0",
     "three": "^0.176.0",
     "vaul": "^1.1.2",
+    "zod": "^3.24.4",
     "zustand": "^5.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## 📌 이슈 번호
Closes #56 

## ✨ 작업 내용

- react-hook-form 기반 label + input 컴포넌트 구성
  - email, password 등 input type을 props로 전달
```typescript
<FormInput
  name="email"
  label="이메일"
  placeholder="이메일을 입력하세요"
  type="email"
/>
```
<img width="250" alt="image" src="https://github.com/user-attachments/assets/679f4a07-441f-4f3d-a24a-46f4ee85573b" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/43daeb54-8058-414a-8f3e-1f08f8eee557" />

- Form 전체 양식(<Form>)은 shadcn으로 사용하시면 됩니다.

코드 예시
```typescript
import { useForm } from "react-hook-form";
import { Form } from "@/components/ui/form";

const form = useForm({
  defaultValues: {
    email: "",
  },
});

const onSubmit = (data: any) => {
  console.log(data);
};

<Form {...form}>
    <form onSubmit={form.handleSubmit(onSubmit)}>
      <p>form 양식은 따로 만드세요</p>
      <FormInput
        name="email"
        label="이메일"
        placeholder="이메일을 입력하세요"
        type="email"
      />
      <button type="submit">임시 제출 버튼</button>
    </form>
  </Form>

```


## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
