### PR TITLE
페이지, API 권한 검사 추가 & 주소 저장 시 행정동 사용

### DIFF
--- a/app/auth/onboarding/components/KakaoMap.tsx
+++ b/app/auth/onboarding/components/KakaoMap.tsx
@@ -22,13 +22,14 @@ export default function KakaoMap({ onSelect }: KakaoMapProps) {
       const newCenter = map.getCenter();
       marker.setPosition(newCenter);
 
-      geocoder.coord2Address(
+      geocoder.coord2RegionCode(
         newCenter.getLng(),
         newCenter.getLat(),
         (result, status) => {
           if (status === window.kakao.maps.services.Status.OK) {
-            const addr = result[0].address;
-            onSelect(addr.address_name, addr.region_3depth_name);
+            const addr = result.find((r) => r.region_type === "H");
+            console.log(addr);
+            if (addr) onSelect(addr.address_name, addr.region_3depth_name);
           }
         },
       );

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -8,6 +8,8 @@ import {
   MessageCircle,
   CircleUserRound,
 } from "lucide-react";
+import { useAuthStore } from "@/store/authStore";
+import { useSession } from "next-auth/react";
 
 const navItems = [
   { key: "", Icon: House, label: "홈" },
@@ -20,13 +22,19 @@ const navItems = [
 export default function Footer() {
   const pathname = usePathname();
   const router = useRouter();
+  const publicId = useAuthStore((state) => state.publicId);
 
   const current = pathname?.split("/")[1] ?? navItems[0].key;
   const activeTab =
     navItems.find((item) => item.key === current)?.key ?? navItems[0].key;
 
   const handleClick = (key: string) => {
-    router.push(`/${key}`);
+    if (key === "users") {
+      if (!publicId) router.push("/login");
+      router.push(`/users/${publicId}`);
+    } else {
+      router.push(`/${key}`);
+    }
   };
 
   return (

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,60 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
+
+
+const PUBLIC_PAGE_REGEX = [/^\/group-buy\/\d+$/];
+const PUBLIC_PAGE_PATHS = ["/login"];
+const PUBLIC_API_PATHS = [
+  "/api/auth",
+  "/api/users/exist",
+  "/api/users/signup",
+];
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const isApiRoute = pathname.startsWith("/api");
+  const isPublicPage = PUBLIC_PAGE_PATHS.includes(pathname) || 
+    PUBLIC_PAGE_REGEX.some((regex) => regex.test(pathname));
+  const isPublicApi =
+    PUBLIC_API_PATHS.some((path) => pathname.startsWith(path)) ||
+    (/^\/api\/group-buy\/\d+$/.test(pathname) && req.method === "GET");
+  
+  const token = await getToken({ req });
+  
+  // 로그인한 유저 /login 접근 시 /map으로 이동
+  if(pathname === "/login" && token){
+    return NextResponse.redirect(new URL('/map', req.url));
+  }
+
+  // 페이지 보호
+  if (!isApiRoute && !isPublicPage && !token) {
+    const loginUrl = new URL("/login", req.url);
+    loginUrl.searchParams.set('callbackUrl', req.nextUrl.pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  // API 보호
+  if (isApiRoute && !isPublicApi && !token) {
+    return NextResponse.json(
+      { message: "로그인이 필요한 서비스입니다." },
+      { status: 401 }
+    );
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [  
+    "/api/:path*",   
+    "/login",           
+    "/users/:path*",
+    "/map/:path*",
+    "/group-buy/:path*",
+    "/share/:path*",
+    "/chat/:path*",
+    "/notification/:path*",
+    "/share-box/:path*",
+    "/auth/:path*"
+  ],
+};


### PR DESCRIPTION
## 📌 이슈 번호
close #60

## ✨ 작업 내용
- middleware.ts 작성
  -  페이지, API 보호(로그인 사용자만 접근 가능) 로직 작성.
  - 로그인한 유저가 로그인 페이지 접근 시에는 2D 페이지로 이동.

- KakaoMap.tsx
  - 좌표에서 주소 변환 시 법정동 대신 행정동 받아오도록 수정.
  - coord2Address -> coord2RegionCode
 
- Footer.tsx
  - 마이페이지 아이콘 클릭 시 현재 로그인한 사용자의 페이지로 이동하도록 수정.
  - zustand authStore에서 publicId 받아서 /users/[publicId]로 이동함.

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
- 주소 입력 페이지 (`/auth/onboarding`)에서 주소 등록 안 하고 페이지 이탈하는 경우 예외 처리 필요.
  - 이 경우 실제로는 비회원이나 token을 들고 있으므로 회원으로 인식함.
  - 나눔, 같이 장보기 등록 기능 구현 후 수정 예정.