### PR TITLE
마이페이지 - 후기 / ShortReview api 연동

### DIFF
--- a/app/api/users/history-count/route.ts
+++ b/app/api/users/history-count/route.ts
@@ -2,6 +2,7 @@ import { GetUserHistoryCountDto } from "@/application/usecases/user/dto/GetUserH
 import { GetUserHistoryCountUsecase } from "@/application/usecases/user/GetUserHistoryCountUsecase";
 import { PrismaGroupBuyRepository } from "@/infra/repositories/prisma/group-buy/PrismaGroupBuyRepository";
 import { PrismaUserRepository } from "@/infra/repositories/prisma/PrismaUserRepository";
+import { PrismaReviewRepository } from "@/infra/repositories/prisma/review/PrismaReviewRepository";
 import { PrismaShareRepository } from "@/infra/repositories/prisma/share/PrismaShareRepository";
 import { NextResponse } from "next/server";
 
@@ -23,7 +24,8 @@ export async function GET(req: Request) {
     const userRepo = new PrismaUserRepository();
     const shareRepo = new PrismaShareRepository();
     const groupBuysRepo = new PrismaGroupBuyRepository();
-    const getUserHistoryCountUsecase = new GetUserHistoryCountUsecase(userRepo,shareRepo,groupBuysRepo);
+    const reviewRepo = new PrismaReviewRepository();
+    const getUserHistoryCountUsecase = new GetUserHistoryCountUsecase(userRepo,shareRepo,groupBuysRepo,reviewRepo);
     const result = await getUserHistoryCountUsecase.execute(getUserHistoryCountDto);
 
     return NextResponse.json({ success: true, result }, { status: 200 });

--- a/app/api/users/reviews/route.ts
+++ b/app/api/users/reviews/route.ts
@@ -1,0 +1,31 @@
+import { GetUserReviewsDto } from "@/application/usecases/user/dto/GetUserReviewsDto";
+import { GetUserReviewsUsecase } from "@/application/usecases/user/GetUserReviewsUsecase";
+import { PrismaUserRepository } from "@/infra/repositories/prisma/PrismaUserRepository";
+import { PrismaReviewRepository } from "@/infra/repositories/prisma/review/PrismaReviewRepository";
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+    try{
+        const url = new URL(req.url);
+        const searchParams = url.searchParams;
+
+        const publicId = searchParams.get("publicId");
+        const page = Number(searchParams.get("page") || "0");
+        const itemsPerPage = Number(searchParams.get("itemsPerPage") || "20");
+
+        const getUserReviewsDto = new GetUserReviewsDto(
+            Number(publicId),
+            page,
+            itemsPerPage,
+        );
+        const userRepo = new PrismaUserRepository();
+        const reviewRepo = new PrismaReviewRepository();
+        const getUserReviewsUsecase = new GetUserReviewsUsecase(userRepo, reviewRepo);
+        const result = await getUserReviewsUsecase.execute(getUserReviewsDto);
+        
+        return NextResponse.json({ success: true, result }, { status: 200 });
+    } catch(error) {
+        console.error("리뷰 조회 실패", error);
+        return NextResponse.json({ success: false, error: "리뷰 조회 실패" }, { status: 500 });
+    }
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { GetUserProfileUsecase } from "@/application/usecases/user/GetUserProfileUsecase";
 import { PrismaNeighborhoodRepository } from '@/infra/repositories/prisma/PrismaNeighborhoodRepository';
 import { PrismaUserRepository } from '@/infra/repositories/prisma/PrismaUserRepository';
+import { GetUserShortReviewsUsecase } from "@/application/usecases/user/GetUserShortReviewsUsecase";
+import { PrismaReviewRepository } from "@/infra/repositories/prisma/review/PrismaReviewRepository";
+import { PrismaShortReviewOptionRepository } from "@/infra/repositories/prisma/review/PrismaShortReviewOptionRepository";
+import { PrismaReviewShortReviewRepository } from "@/infra/repositories/prisma/review/PrismaReviewShortReviewRepository";
 
 export async function GET(req: Request) {
     const { searchParams } = new URL(req.url);
@@ -12,10 +16,18 @@ export async function GET(req: Request) {
         const neighborRepo = new PrismaNeighborhoodRepository();
         const getUserProfileUsecase = new GetUserProfileUsecase(userRepo, neighborRepo);
 
-        const result = await getUserProfileUsecase.execute(publicId);
+        const reviewRepo = new PrismaReviewRepository();
+        const reviewShortReviewRepo = new PrismaReviewShortReviewRepository();
+        const shortReviewOptionRepo = new PrismaShortReviewOptionRepository();
+        const getUserShortReviewsUsecase = new GetUserShortReviewsUsecase(userRepo, reviewRepo, reviewShortReviewRepo, shortReviewOptionRepo);
 
+        const [ profile, shortReview ] = await Promise.all ([
+          getUserProfileUsecase.execute(publicId),
+          getUserShortReviewsUsecase.execute(publicId)
+        ])
+        
         return NextResponse.json(
-            {message: '조회 성공', userProfile: result},
+            {message: '조회 성공', result: {profile, shortReview}},
             {status: 200}
         );
   } catch (error) {

--- a/app/map/components/MapList.tsx
+++ b/app/map/components/MapList.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 import { useInfiniteScroll } from "@/hooks/useInfinityScroll";
 import { useMapFilterStore } from "@/stores/useMapFilterStore";
 import { ListCard } from "@/components/common/ListCard";
-import { LoadingLottie } from "./LoadingLottie";
+import { LoadingFoodLottie } from "@/components/lotties/LoadingFoodLottie";
 import { format } from "date-fns";
 
 interface MapListProps {
@@ -136,7 +136,7 @@ export function MapList({ selectedId }: MapListProps) {
           id={""}
         />
       ))}
-      {loading && <LoadingLottie />}
+      {loading && <LoadingFoodLottie />}
       <div ref={ref} className="h-4/5" />
     </div>
   );

--- a/app/users/[publicId]/page.tsx
+++ b/app/users/[publicId]/page.tsx
@@ -5,7 +5,7 @@ import Header from "@/components/common/Header";
 import Footer from "@/components/common/Footer";
 import Loading from "@/components/common/Loading";
 import { getScoreVisual } from "@/app/users/utils";
-import UsersNav from "@/app/users/components/UsersNav";
+import UsersNav, { type shortReview } from "@/app/users/components/UsersNav";
 import Profile from "@/app/users/components/Profile";
 import UserLocation from "@/app/users/components/UserLocation";
 import ShareScore from "@/app/users/components/ShareScore";
@@ -23,6 +23,7 @@ export default function userPage() {
   const { publicId, isMyAccount } = useUserInfo();
 
   const [user, setUser] = useState<User | null>(null);
+  const [shortReviews, setShortReviews] = useState<shortReview[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -34,7 +35,9 @@ export default function userPage() {
 
         if (!res.ok) throw new Error("유저 정보 조회 실패");
         const data = await res.json();
-        setUser(data.userProfile);
+
+        setUser(data.result.profile);
+        setShortReviews(data.result.shortReview);
       } catch (error) {
         console.error(error);
       } finally {
@@ -72,7 +75,11 @@ export default function userPage() {
             userName={user.nickName}
             profileImage={user.profileUrl}
           />
-          <UsersNav isMyAccount={isMyAccount} publicId={publicId as string} />
+          <UsersNav
+            isMyAccount={isMyAccount}
+            publicId={publicId as string}
+            shortReviews={shortReviews}
+          />
         </section>
       </div>
       <Footer />

--- a/app/users/[publicId]/reviews/page.tsx
+++ b/app/users/[publicId]/reviews/page.tsx
@@ -46,6 +46,11 @@ export default function Reviews() {
           총 받은 후기
           <span className="text-primary pl-1">{counts.review}</span>
         </div>
+        {items.length === 0 && !loading && (
+          <p className="pt-8 text-center text-gray-400">
+            아직 받은 후기가 없어요.
+          </p>
+        )}
         <ul className="flex flex-col gap-4 pt-3">
           {items.map((item) => (
             <ReviewListItem key={item.id} {...(item as ReviewListItemProps)} />

--- a/app/users/[publicId]/reviews/page.tsx
+++ b/app/users/[publicId]/reviews/page.tsx
@@ -1,7 +1,17 @@
+"use client";
+
 import SubHeader from "@/components/common/SubHeader";
-import ReviewListItem from "../../components/ReviewListItem";
+import ReviewListItem from "@/app/users/components/ReviewListItem";
+import { useUserInfo } from "@/app/users/hooks/useUserInfo";
+import { useTotalCounts } from "@/app/users/hooks/useTotalCounts";
 
 export default function Reviews() {
+  const { publicId } = useUserInfo();
+  const { counts } = useTotalCounts({
+    publicId,
+    type: "review",
+    tabType: "review",
+  });
   const data = [
     {
       id: "diddididcsfdm",
@@ -24,7 +34,8 @@ export default function Reviews() {
       <SubHeader titleText="후기" />
       <div className="pt-7 px-4">
         <div className="text-right body-sm text-zinc-600">
-          총 받은 후기<span className="text-primary pl-1">{data.length}</span>
+          총 받은 후기
+          <span className="text-primary pl-1">{counts.review}</span>
         </div>
         <ul className="flex flex-col gap-4">
           {data.map((item) => (

--- a/app/users/[publicId]/reviews/page.tsx
+++ b/app/users/[publicId]/reviews/page.tsx
@@ -8,7 +8,7 @@ import ReviewListItem, {
 import { useUserInfo } from "@/app/users/hooks/useUserInfo";
 import { useTotalCounts } from "@/app/users/hooks/useTotalCounts";
 import { useInfiniteScroll } from "@/hooks/useInfinityScroll";
-import LoadingLottie from "@/components/lotties/LoadingLottie";
+import { LoadingFoodLottie } from "@/components/lotties/LoadingFoodLottie";
 
 export default function Reviews() {
   const { publicId } = useUserInfo();
@@ -52,7 +52,7 @@ export default function Reviews() {
           ))}
         </ul>
         <div ref={ref} className="h-4/5" />
-        {loading && <LoadingLottie />}
+        {loading && <LoadingFoodLottie />}
         {items.length !== 0 && !hasMore && (
           <p className="pt-8 text-center text-gray-400">
             모든 항목을 불러왔어요.

--- a/app/users/components/HistoryItemList.tsx
+++ b/app/users/components/HistoryItemList.tsx
@@ -1,4 +1,4 @@
-import { LoadingLottie } from "@/app/map/components/LoadingLottie";
+import { LoadingFoodLottie } from "@/components/lotties/LoadingFoodLottie";
 import {
   GroupBuyListCard,
   type GroupBuyListCardProps,
@@ -42,7 +42,7 @@ export function HistoryItemList({
         ))}
       </ul>
       <div ref={refTarget} className="h-4/5" />
-      {loading && <LoadingLottie />}
+      {loading && <LoadingFoodLottie />}
       {items.length !== 0 && !hasMore && (
         <p className="pt-8 text-center text-gray-400">
           모든 항목을 불러왔어요.

--- a/app/users/components/HistorySection.tsx
+++ b/app/users/components/HistorySection.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import SubHeader from "@/components/common/SubHeader";
 import { useInfiniteScroll } from "@/hooks/useInfinityScroll";
-import { useTabCounts } from "@/app/users/hooks/useTabCounts";
+import { useTotalCounts } from "@/app/users/hooks/useTotalCounts";
 import { HistoryItemList } from "@/app/users/components/HistoryItemList";
 import type { ListCardProps } from "@/components/common/ListCard";
 import type { ShareListCardProps } from "@/app/users/components/ShareListCard";
@@ -24,7 +24,7 @@ export function HistorySection({
   isMyAccount,
   tabType,
 }: HistorySectionProps) {
-  const { counts } = useTabCounts({ publicId, type, tabType });
+  const { counts } = useTotalCounts({ publicId, type, tabType });
   const [currentTab, setCurrentTab] = useState<string>(
     tabType === "status" ? "active" : "share",
   );

--- a/app/users/components/ReviewListItem.tsx
+++ b/app/users/components/ReviewListItem.tsx
@@ -1,36 +1,38 @@
 import Image from "next/image";
 
 export interface ReviewListItemProps {
-  profileImgUrl: string;
-  nickName: string;
-  detailReview: string;
-  shareScore: number;
+  id: number;
+  writerProfileUrl: string;
+  writerName: string;
+  reviewContent: string;
+  writerScore: number;
 }
 
 export default function ReviewListItem({
-  profileImgUrl,
-  nickName,
-  detailReview,
-  shareScore,
+  writerProfileUrl,
+  writerName,
+  reviewContent,
+  writerScore,
 }: ReviewListItemProps) {
   return (
     <li>
       <div className="flex items-center gap-2">
         <div className="flex-shrink-0 rounded-full overflow-hidden">
           <Image
-            src={profileImgUrl}
+            src={writerProfileUrl}
             width={38}
             height={38}
-            alt={`${nickName} 프로필`}
+            className="w-9 h-9 object-cover"
+            alt={`${writerName} 프로필`}
           />
         </div>
         <div>
-          <div className="text-md/4">{nickName}</div>
-          <div className="text-primary badge-medium">{shareScore}°C</div>
+          <div className="text-md/4">{writerName}</div>
+          <div className="text-primary badge-medium">{writerScore}°C</div>
         </div>
       </div>
       <div className="bg-zinc-200 rounded-[25px] rounded-tl-none p-4 body-sm mt-2.5">
-        {detailReview}
+        {reviewContent}
       </div>
     </li>
   );

--- a/app/users/components/UsersNav.tsx
+++ b/app/users/components/UsersNav.tsx
@@ -3,16 +3,22 @@ import { cn } from "@/lib/utils";
 import { ChevronRight, Users } from "lucide-react";
 import Link from "next/link";
 
+export interface shortReview {
+  id: number;
+  content: string;
+  count: number;
+}
+
 interface usersNavProps {
   publicId: string;
   isMyAccount: boolean;
-  mannerReviews?: []; // 임시
+  shortReviews?: shortReview[];
 }
 
 export default function UsersNav({
   publicId,
   isMyAccount,
-  mannerReviews,
+  shortReviews,
 }: usersNavProps) {
   const usersLinks = [
     { label: "나눔 내역", path: "share-histories" },
@@ -38,14 +44,17 @@ export default function UsersNav({
           {label}
           <ChevronRight />
         </Link>
-        {isReview && (
+        {isReview && shortReviews && shortReviews.length > 0 && (
           <ul className="px-4 flex flex-col gap-1.5 pt-1">
-            <li className="flex gap-1 items-center">
-              <div className="w-[130px] body-sm">나눔 재료가 신선해요</div>
-              <Badge variant="review">
-                <Users size={10} />1
-              </Badge>
-            </li>
+            {shortReviews.map((review) => (
+              <li key={review.id} className="flex gap-1 items-center">
+                <div className="w-[130px] body-sm">{review.content}</div>
+                <Badge variant="review">
+                  <Users size={12} />
+                  {review.count}
+                </Badge>
+              </li>
+            ))}
           </ul>
         )}
       </li>

--- a/app/users/hooks/useTotalCounts.ts
+++ b/app/users/hooks/useTotalCounts.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 
-interface UseTabCountsProps {
+interface useTotalCountsProps {
   publicId: string;
-  type: "share" | "group-buy" | "participation";
-  tabType: "status" | "participation";
+  type: "share" | "group-buy" | "participation" | "review";
+  tabType: "status" | "participation" | "review";
 }
 
-export function useTabCounts({ publicId, type, tabType }: UseTabCountsProps) {
+export function useTotalCounts({ publicId, type, tabType }: useTotalCountsProps) {
   const [counts, setCounts] = useState<Record<string, number>>({});
 
   useEffect(() => {

--- a/app/users/hooks/useUserInfo.ts
+++ b/app/users/hooks/useUserInfo.ts
@@ -4,7 +4,7 @@ import { useParams } from "next/navigation";
 
 export function useUserInfo() {
   const params = useParams();
-  const publicId = params.publicId;
+  const publicId = params.publicId as string;
   const { data: session, status } = useSession();
   const myPublicId = session?.user.publicId;
 

--- a/application/usecases/user/GetUserHistoryCountUsecase.ts
+++ b/application/usecases/user/GetUserHistoryCountUsecase.ts
@@ -65,7 +65,7 @@ export class GetUserHistoryCountUsecase {
     }
 
     if (tabType === "review") {
-      const review = await this.reviewRepo.getCount({ recipientId: user?.id });
+      const review = await this.reviewRepo.getCount({ recipientId: user?.id, content: { not: null,}, });
       return { review };
     }
 

--- a/application/usecases/user/GetUserHistoryCountUsecase.ts
+++ b/application/usecases/user/GetUserHistoryCountUsecase.ts
@@ -4,12 +4,14 @@ import type { UserRepository } from "@/domain/repositories/UserRepository";
 import type { ShareRepository } from "@/domain/repositories/share/ShareRepository";
 import type { GetUserHistoryCountDto } from "./dto/GetUserHistoryCountDto";
 import { getShareStatusCondition } from "./utils/getStatusCondition";
+import type { ReviewRepository } from "@/domain/repositories/review/ReviewRepository";
 
 export class GetUserHistoryCountUsecase {
   constructor(
     private userRepo: UserRepository,
     private shareRepo: ShareRepository,
     private groupbuyRepo: GroupBuyRepository,
+    private reviewRepo: ReviewRepository,
   ) {}
 
   async execute(
@@ -28,36 +30,44 @@ export class GetUserHistoryCountUsecase {
               ...getShareStatusCondition(status),
             };
 
-            return this.shareRepo.getCount(where)
-          }));
+            return this.shareRepo.getCount(where);
+          }),
+        );
         return { active, completed, expired };
       }
       if (type === "group-buy") {
         const [active, completed] = await Promise.all(
-          statuses.map((status) =>{
+          statuses.map((status) => {
             const where = {
               organizerId: user?.id,
               status: status === "active" ? 0 : 1,
             };
 
-            return this.groupbuyRepo.getCount(where)
-          }));
+            return this.groupbuyRepo.getCount(where);
+          }),
+        );
         return { active, completed };
       }
-    };
+    }
 
     if (tabType === "participation") {
       const [share, groupbuy] = await Promise.all([
-          this.shareRepo.getCount({recipientId: user?.id,}),
-          this.groupbuyRepo.getCount({
-            participants: {
-              some : {
-                userId: user?.id,
-              }
-            }}),
+        this.shareRepo.getCount({ recipientId: user?.id }),
+        this.groupbuyRepo.getCount({
+          participants: {
+            some: {
+              userId: user?.id,
+            },
+          },
+        }),
       ]);
       return { share, groupbuy };
-    };
+    }
+
+    if (tabType === "review") {
+      const review = await this.reviewRepo.getCount({ recipientId: user?.id });
+      return { review };
+    }
 
     throw new Error("Invalid type or tabType");
   }

--- a/application/usecases/user/GetUserHistoryCountUsecase.ts
+++ b/application/usecases/user/GetUserHistoryCountUsecase.ts
@@ -65,7 +65,7 @@ export class GetUserHistoryCountUsecase {
     }
 
     if (tabType === "review") {
-      const review = await this.reviewRepo.getCount({ recipientId: user?.id, content: { not: null,}, });
+      const review = await this.reviewRepo.getCount({ recipientId: user?.id, content: { not: "",}, });
       return { review };
     }
 

--- a/application/usecases/user/GetUserReviewsUsecase.ts
+++ b/application/usecases/user/GetUserReviewsUsecase.ts
@@ -1,0 +1,38 @@
+import type { ReviewRepository } from "@/domain/repositories/review/ReviewRepository";
+import type { UserRepository } from "@/domain/repositories/UserRepository";
+import type { GetUserReviewsDto } from "./dto/GetUserReviewsDto";
+import type { GetUserReviewsResultDto } from "./dto/GetUserReviewsResultDto";
+
+export class GetUserReviewsUsecase {
+  constructor(
+    private userRepo: UserRepository,
+    private reviewRepo: ReviewRepository,
+  ) {}
+
+  async execute(reviewsByUser: GetUserReviewsDto): Promise<GetUserReviewsResultDto[] | null> {
+    const { publicId, page, itemsPerPage } = reviewsByUser;
+    const user = await this.userRepo.findByPublicId(publicId);
+
+    if (!user) {
+      return null;
+    }
+
+    const data = await this.reviewRepo.getUserReviews({
+      recipientId: user.id,
+      offset: page * itemsPerPage,
+      itemsPerPage,
+    });
+
+    if (!data || data.length === 0) {
+      return [];
+    }
+
+    return data.map((review) => ({
+      id: review.id,
+      reviewContent: review.content,
+      writerName: review.writerNickname,
+      writerProfileUrl: review.writerProfileUrl,
+      writerScore: review.writerShareScore,
+    }));
+  }
+}

--- a/application/usecases/user/GetUserShortReviewsUsecase.ts
+++ b/application/usecases/user/GetUserShortReviewsUsecase.ts
@@ -1,0 +1,41 @@
+import type { ReviewRepository } from "@/domain/repositories/review/ReviewRepository";
+import type { GetUserShortReviewsDto } from "./dto/GetUserShortReviewsDto";
+import type { ReviewShortReviewRepository } from "@/domain/repositories/review/ReviewShortReviewRepository";
+import type { ShortReviewOptionRepository } from "@/domain/repositories/review/ShortReviewOptionRepository";
+import type { UserRepository } from "@/domain/repositories/UserRepository";
+
+export class GetUserShortReviewsUsecase {
+  constructor(
+    private userRepo: UserRepository,
+    private reviewRepo: ReviewRepository,
+    private reviewShortReviewRepo: ReviewShortReviewRepository,
+    private shortReviewOptionRepo: ShortReviewOptionRepository,
+  ) {}
+
+  async execute(id: number): Promise<GetUserShortReviewsDto[]> {
+    const user = await this.userRepo.findByPublicId(id);
+    if (!user) throw new Error("User not found");
+
+    const reviewIds = await this.reviewRepo.getbyRecipientId(user.id);
+    if (reviewIds.length === 0) return [];
+
+    const counts =
+      await this.reviewShortReviewRepo.getCountShortReviews(reviewIds);
+
+    const result = await Promise.all(
+      counts.map(async (counts) => {
+        const content = await this.shortReviewOptionRepo.getContentById(
+          counts.optionId,
+        );
+        return {
+          id: counts.optionId,
+          content: content,
+          count: counts.count,
+        };
+      }),
+    );
+
+    return result;
+  }
+}
+

--- a/application/usecases/user/dto/GetUserHistoryCountDto.ts
+++ b/application/usecases/user/dto/GetUserHistoryCountDto.ts
@@ -1,9 +1,7 @@
-import type { participantsType, StatusType } from "@/types/types";
-
 export class GetUserHistoryCountDto {
   constructor(
     public publicId: number,
-    public type: "share" | "group-buy" | "participation",
-    public tabType: "status" | "participation",
+    public type: "share" | "group-buy" | "participation" | "review",
+    public tabType: "status" | "participation" | "review",
   ) {}
 }

--- a/application/usecases/user/dto/GetUserReviewsDto.ts
+++ b/application/usecases/user/dto/GetUserReviewsDto.ts
@@ -1,0 +1,7 @@
+export class GetUserReviewsDto {
+  constructor(
+    public publicId: number,
+    public page: number,
+    public itemsPerPage: number,
+  ) {}
+}

--- a/application/usecases/user/dto/GetUserReviewsResultDto.ts
+++ b/application/usecases/user/dto/GetUserReviewsResultDto.ts
@@ -1,0 +1,9 @@
+export class GetUserReviewsResultDto {
+  constructor(
+    public id: number,
+    public reviewContent: string | null,
+    public writerName: string,
+    public writerScore: number,
+    public writerProfileUrl: string,
+  ) {}
+}

--- a/application/usecases/user/dto/GetUserShortReviewsDto.ts
+++ b/application/usecases/user/dto/GetUserShortReviewsDto.ts
@@ -1,0 +1,7 @@
+export class GetUserShortReviewsDto {
+  constructor(
+    public id: number,
+    public content: string,
+    public count: number,
+  ) {}
+}

--- a/components/common/Loading.tsx
+++ b/components/common/Loading.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import LoadingLottie from "../lotties/LoadingLottie";
 

--- a/components/lotties/LoadingFoodLottie.tsx
+++ b/components/lotties/LoadingFoodLottie.tsx
@@ -2,7 +2,7 @@
 
 import { DotLottieReact } from "@lottiefiles/dotlottie-react";
 
-export function LoadingLottie() {
+export function LoadingFoodLottie() {
   return (
     <div className="w-50 h-50 m-auto">
       <DotLottieReact src="/assets/lotties/loadingFood.lottie" loop autoplay />

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -19,7 +19,8 @@ const badgeVariants = cva(
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         warning: "badge-bold bg-[var(--warning)] rounded-[6px]",
         isDday: "badge-bold bg-[var(--light-green-300)] rounded-[6px]",
-        review: "badge-sm bg-[var(--light-green-300)] rounded-[6px]",
+        review:
+          "badge-sm bg-[var(--light-green-300)] rounded-[6px] px-1.5 [&>svg]:size-3",
         done: "badge-bold bg-zinc-400 rounded-[6px]",
         location: "badge-medium bg-zinc-600 rounded-[15px]",
         share: "badge-medium bg-[var(--secondary)] rounded-[15px]",

--- a/domain/repositories/review/ReviewRepository.ts
+++ b/domain/repositories/review/ReviewRepository.ts
@@ -1,0 +1,12 @@
+import type { Prisma, Review } from "@/prisma/generated";
+
+export interface GetUserReviews {
+  publicId: string,
+  offset: number,
+  itemsPerPage: number,
+}
+
+export interface ReviewRepository {
+    getUserReviews: ( params: GetUserReviews) => Promise<Review[]>;
+    getCount(where: Prisma.ReviewWhereInput): Promise<number>;
+}

--- a/domain/repositories/review/ReviewRepository.ts
+++ b/domain/repositories/review/ReviewRepository.ts
@@ -1,12 +1,19 @@
 import type { Prisma, Review } from "@/prisma/generated";
 
 export interface GetUserReviews {
-  publicId: string,
+  recipientId: string,
   offset: number,
   itemsPerPage: number,
 }
 
+export interface WriterProfile {
+  writerShareScore: number;
+  writerNickname: string;
+  writerProfileUrl: string;
+}
+
+
 export interface ReviewRepository {
-    getUserReviews: ( params: GetUserReviews) => Promise<Review[]>;
+    getUserReviews(params: GetUserReviews): Promise<(Review & WriterProfile)[]>;
     getCount(where: Prisma.ReviewWhereInput): Promise<number>;
 }

--- a/domain/repositories/review/ReviewRepository.ts
+++ b/domain/repositories/review/ReviewRepository.ts
@@ -14,6 +14,7 @@ export interface WriterProfile {
 
 
 export interface ReviewRepository {
-    getUserReviews(params: GetUserReviews): Promise<(Review & WriterProfile)[]>;
-    getCount(where: Prisma.ReviewWhereInput): Promise<number>;
+  getCount(where: Prisma.ReviewWhereInput): Promise<number>;
+  getUserReviews(params: GetUserReviews): Promise<(Review & WriterProfile)[]>;
+  getbyRecipientId(id: string): Promise<number[]>;
 }

--- a/domain/repositories/review/ReviewShortReviewRepository.ts
+++ b/domain/repositories/review/ReviewShortReviewRepository.ts
@@ -1,0 +1,8 @@
+export interface optionsCount {
+  optionId: number;
+  count: number;
+}
+
+export interface ReviewShortReviewRepository {
+  getCountShortReviews(reviewIds: number[]): Promise<optionsCount[]>;
+}

--- a/domain/repositories/review/ShortReviewOptionRepository.ts
+++ b/domain/repositories/review/ShortReviewOptionRepository.ts
@@ -1,0 +1,3 @@
+export interface ShortReviewOptionRepository {
+    getContentById(id: number): Promise<string>;
+}

--- a/infra/repositories/prisma/review/PrismaReviewRepository.ts
+++ b/infra/repositories/prisma/review/PrismaReviewRepository.ts
@@ -24,7 +24,7 @@ export class PrismaReviewRepository implements ReviewRepository {
     const reviews = await this.prisma.review.findMany({
       where: {
         recipientId: recipientId,
-        content: { not: null },
+        content: { not: "" },
       },
       skip: offset,
       take: itemsPerPage,

--- a/infra/repositories/prisma/review/PrismaReviewRepository.ts
+++ b/infra/repositories/prisma/review/PrismaReviewRepository.ts
@@ -1,0 +1,33 @@
+import type {
+  GetUserReviews,
+  ReviewRepository,
+} from "@/domain/repositories/review/ReviewRepository";
+import { type Prisma, PrismaClient, type Review } from "@/prisma/generated";
+
+export class PrismaReviewRepository implements ReviewRepository {
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
+
+  async getUserReviews({
+    publicId,
+    offset,
+    itemsPerPage,
+  }: GetUserReviews): Promise<Review[]> {
+    return this.prisma.review.findMany({
+      where: { recipientId: publicId },
+      skip: offset,
+      take: itemsPerPage,
+      orderBy: { createdAt: "desc" },
+      include: {
+        writer: true,
+      },
+    });
+  }
+
+  async getCount(where: Prisma.ReviewWhereInput): Promise<number> {
+    return this.prisma.review.count({ where });
+  }
+}

--- a/infra/repositories/prisma/review/PrismaReviewRepository.ts
+++ b/infra/repositories/prisma/review/PrismaReviewRepository.ts
@@ -12,6 +12,10 @@ export class PrismaReviewRepository implements ReviewRepository {
     this.prisma = new PrismaClient();
   }
 
+  async getCount(where: Prisma.ReviewWhereInput): Promise<number> {
+    return this.prisma.review.count({ where });
+  }
+
   async getUserReviews({
     recipientId,
     offset,
@@ -20,7 +24,7 @@ export class PrismaReviewRepository implements ReviewRepository {
     const reviews = await this.prisma.review.findMany({
       where: {
         recipientId: recipientId,
-        content: { not: null,},
+        content: { not: null },
       },
       skip: offset,
       take: itemsPerPage,
@@ -44,7 +48,12 @@ export class PrismaReviewRepository implements ReviewRepository {
     }));
   }
 
-  async getCount(where: Prisma.ReviewWhereInput): Promise<number> {
-    return this.prisma.review.count({ where });
+  async getbyRecipientId(id: string): Promise<number[]> {
+    const reviews = await this.prisma.review.findMany({
+      where: { recipientId: id },
+      select: { id: true },
+    });
+
+    return reviews.map((r) => r.id);
   }
 }

--- a/infra/repositories/prisma/review/PrismaReviewShortReviewRepository.ts
+++ b/infra/repositories/prisma/review/PrismaReviewShortReviewRepository.ts
@@ -1,0 +1,36 @@
+import type {
+  optionsCount,
+  ReviewShortReviewRepository,
+} from "@/domain/repositories/review/ReviewShortReviewRepository";
+import { PrismaClient } from "@/prisma/generated";
+
+export class PrismaReviewShortReviewRepository
+  implements ReviewShortReviewRepository
+{
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
+
+  async getCountShortReviews(reviewIds: number[]): Promise<optionsCount[]> {
+    const counts = await this.prisma.reviewShortReview.groupBy({
+      by: ["shortReviewOptionId"],
+      where: {
+        reviewId: {
+          in: reviewIds,
+        },
+      },
+      orderBy:{ shortReviewOptionId: "asc" },
+      _count: {
+        shortReviewOptionId: true,
+      },
+      
+    });
+
+    return counts.map((count) => ({
+      optionId: count.shortReviewOptionId,
+      count: count._count.shortReviewOptionId,
+    }));
+  }
+}

--- a/infra/repositories/prisma/review/PrismaShortReviewOptionRepository.ts
+++ b/infra/repositories/prisma/review/PrismaShortReviewOptionRepository.ts
@@ -1,0 +1,25 @@
+import type { ShortReviewOptionRepository } from "@/domain/repositories/review/ShortReviewOptionRepository";
+import { PrismaClient } from "@/prisma/generated";
+
+export class PrismaShortReviewOptionRepository
+  implements ShortReviewOptionRepository
+{
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
+  
+  async getContentById(id: number): Promise<string> {
+    const option = await this.prisma.shortReviewOption.findUnique({
+      where: { id },
+      select: { content: true },
+    });
+
+    if (!option) {
+      throw new Error(`Short review option with id ${id} not found`);
+    }
+
+    return option.content;
+  }
+}

--- a/seeds/seed-backup.ts
+++ b/seeds/seed-backup.ts
@@ -13,7 +13,6 @@ async function main() {
     },
   });
 
-
   // 사용자 생성
   const user1 = await prisma.user.create({
     data: {
@@ -42,10 +41,11 @@ async function main() {
       capacity: 10,
       desiredItem: "식료품",
       meetingDate: new Date(),
-      locationAddress: "서울시 관악구 봉천동 123",
       locationNote: "근처 마트",
+      lat: 37.4783,
+      lng: 126.9517,
       description: "관악구 주민들을 위한 공동 장보기 모임입니다.",
-      status: "진행 중",
+      status: 0,
     },
   });
 
@@ -75,10 +75,9 @@ async function main() {
       meetingDate: new Date(),
       lat: 37.4783,
       lng: 126.9517,
-      locationAddress: "서울시 관악구 봉천동 123",
       locationNote: "채소 나눔 장소",
       description: "남는 채소를 나누는 행사입니다.",
-      status: "완료",
+      status: 1,
     },
   });
 
@@ -120,14 +119,6 @@ async function main() {
       shareId: share.id,
       grade: 2,
       content: "채소 나눔에 감사드립니다!",
-    },
-  });
-
-  // 알림 생성
-  await prisma.notification.create({
-    data: {
-      userId: user2.id,
-      content: "새로운 나눔 채팅 메시지가 있습니다.",
     },
   });
 

--- a/seeds/seed-daily.ts
+++ b/seeds/seed-daily.ts
@@ -46,6 +46,7 @@ async function main() {
   const shareItems = await prisma.shareItem.findMany();
 
   const now = new Date();
+  const formattedDate = now.toISOString().substring(0, 10).replace(/-/g, "");
 
   for (const item of shareItems) {
     const imageUrls = ITEM_IMAGE_MAP[item.name];
@@ -54,7 +55,7 @@ async function main() {
         shareItemId: item.id,
         neighborhoodId: TEST_NEIGHBORHOOD_ID,
         ownerId: TEST_USER_ID,
-        title: `[더미] ${item.name} 나눔`,
+        title: `[더미] ${item.name} 나눔_${formattedDate}`,
         description: `테스트용 ${item.name} 나눔입니다.`,
         lat: 37.4784,
         lng: 126.9516,


### PR DESCRIPTION
## 📌 이슈 번호
Closes #17 

## ✨ 작업 내용
- 마이페이지 - 최 하단 shortReview api 연동
   - 데이터로 노출 - 없으면 나오지 않음
- 마이페이지 - 후기 페이지 api 연동
   - 총 개수 통합 history-count api 에 추가
   - 상세 후기가 있는 경우에만 노출
- 기타 작업 
   - 데일리 더미 데이터 title 에 날짜 들어가도록 수정 (seeds/seed-daily.ts)
   - 무한 스크롤 시 로딩에 도는 과일 로딩 로티는 전체 공통으로 이동 (LoadingFoodLottie)

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)
https://github.com/user-attachments/assets/32b54fc9-706b-46d5-8b1c-0458b12d8d0a

## 💬 기타 참고 사항
