### PR TITLE
나눔함 UI 수정 및 등록 시간 기준 24시간 지난건 안불러오게 하기

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -55,7 +55,6 @@ export default function ChatList() {
           data.sort((a: GroupBuyChatListItem, b: GroupBuyChatListItem) =>
             (b.lastMessageAt || "") > (a.lastMessageAt || "") ? 1 : -1,
           );
-          console.log("togetherData", data);
           setTogetherData(data);
         });
     }

--- a/app/share-box/[publicId]/page.tsx
+++ b/app/share-box/[publicId]/page.tsx
@@ -87,6 +87,7 @@ export default function ShareBoxPage() {
       .then((res) => res.json())
       .then((data) => {
         setShareList(data);
+        console.log("Share List Data:", data);
       });
   }, [publicId]);
 
@@ -148,7 +149,7 @@ export default function ShareBoxPage() {
     />
   );
   return (
-    <main className="w-full h-[80vh]">
+    <main className="w-full h-[calc(100vh-56px)]">
       <Header />
       <h1 className="text-2xl text-center my-4">
         {userInfo ? `${userInfo.nickname} 님의 공유함` : "공유함"}
@@ -185,7 +186,7 @@ export default function ShareBoxPage() {
         open={!!selectedItem}
         action={(open) => !open && setSelectedItem(null)}
         title={selectedItem?.title || ""}
-        image={selectedItem?.image || ""}
+        imageUrls={selectedItem?.imageUrls || []}
         description={selectedItem?.description || ""}
         remainingHours={selectedItem?.remainingHours || ""}
         shareItem={selectedItem?.name || ""}

--- a/app/share-box/[publicId]/page.tsx
+++ b/app/share-box/[publicId]/page.tsx
@@ -87,7 +87,6 @@ export default function ShareBoxPage() {
       .then((res) => res.json())
       .then((data) => {
         setShareList(data);
-        console.log("Fetched share list:", data);
       });
   }, [publicId]);
 
@@ -97,7 +96,6 @@ export default function ShareBoxPage() {
       .then((res) => res.json())
       .then((data) => {
         setUserInfo(data);
-        console.log("Fetched user Info:", data);
       });
   }, [publicId]);
 

--- a/app/share-box/components/BottomSheet.tsx
+++ b/app/share-box/components/BottomSheet.tsx
@@ -17,7 +17,7 @@ interface BottomSheetProps {
   open: boolean;
   action: (open: boolean) => void;
   title: string;
-  image: string;
+  imageUrls: string[];
   description: string;
   remainingHours: string;
   shareItem?: string;
@@ -31,7 +31,7 @@ export default function BottomSheet({
   open,
   action,
   title,
-  image,
+  imageUrls,
   description,
   remainingHours,
   shareItem,
@@ -49,11 +49,13 @@ export default function BottomSheet({
   return (
     <Drawer open={open} onOpenChange={action}>
       <DrawerContent>
-        <div className="mx-auto w-full max-w-sm overflow-y-auto scrollbar-hide">
-          <DrawerTitle className="title-md mt-9 mb-4">{title}</DrawerTitle>
+        <div className="mx-auto w-full max-w-sm overflow-y-auto scrollbar-hide mb-6">
+          <DrawerTitle className="title-md mt-8 mb-4">{title}</DrawerTitle>
           <Carousel
             images={
-              image ? [image] : ["/assets/images/example/default-profile.png"]
+              imageUrls.length > 0
+                ? imageUrls
+                : ["/assets/images/example/default-profile.png"]
             }
           />
           <Content
@@ -63,7 +65,7 @@ export default function BottomSheet({
           />
           {lat && lng && location && (
             <KakaoMapDetail
-              width="361px"
+              width="384px"
               height="136px"
               lat={lat}
               lng={lng}

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -72,7 +72,7 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="bg-[#202430] mx-auto mt-[9px] hidden h-[3px] w-[50px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="bg-[#202430] mx-auto mt-[9px] mb-5 hidden h-[3px] w-[50px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/infra/repositories/prisma/share-box/PrismaShareListRepository.ts
+++ b/infra/repositories/prisma/share-box/PrismaShareListRepository.ts
@@ -9,10 +9,15 @@ export class PrismaShareListRepository implements ShareListRepository {
   }
 
   async findById(userId: string): Promise<ShareWithRelations[]> {
+    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
     return await this.prisma.share.findMany({
       where: {
         ownerId: userId,
         status: { not: 2 },
+        createdAt: {
+          gte: twentyFourHoursAgo,
+        },
       },
       include: {
         images: true,


### PR DESCRIPTION
## ✨ 작업 내용

- 바텀시트 ui를 수정했습니다.
- 마진,패딩, 그리고 캐러셀에 이미지 하나만 보이던 오류도 수정했습니다.
- PrismaShareLIstRepository에서 24시간 지난건 가져오지 않게 수정했습니다.

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
