### PR TITLE
회원가입 에러 수정

### DIFF
--- a/app/auth/onboarding/components/ButtonSection.tsx
+++ b/app/auth/onboarding/components/ButtonSection.tsx
@@ -4,12 +4,21 @@ import { Button } from "@/components/ui/button";
 
 interface ButtonSectionProps {
   onClick: () => void;
+  disabled?: boolean;
 }
 
-export default function ButtonSection({ onClick }: ButtonSectionProps) {
+export default function ButtonSection({
+  onClick,
+  disabled,
+}: ButtonSectionProps) {
   return (
     <section className="absolute bottom-0 z-50 w-full py-3 px-4 bg-white border-t-1 border-zinc-300">
-      <Button variant="joinFullBtn" size="lg" onClick={onClick}>
+      <Button
+        variant="joinFullBtn"
+        size="lg"
+        onClick={onClick}
+        disabled={disabled}
+      >
         위치 선택 완료
       </Button>
     </section>

--- a/app/auth/onboarding/page.tsx
+++ b/app/auth/onboarding/page.tsx
@@ -17,6 +17,7 @@ export default function OnboardingPage() {
     address: string;
     neighborhoodName: string;
   } | null>(null);
+  const [hasUpdated, setHasUpdated] = useState(false);
 
   const onSelect = useCallback((address: string, neighborhoodName: string) => {
     setLocation({ address, neighborhoodName });
@@ -49,20 +50,21 @@ export default function OnboardingPage() {
       });
 
       await update({ forceRefresh: true });
+      setHasUpdated(true);
       router.replace("/map");
-      router.refresh();
     } catch (err) {
       console.error(err);
     }
   };
 
   useEffect(() => {
+    if (hasUpdated) return;
     if (status === "authenticated" && session?.user?.publicId) {
       toast.warning("잘못된 접근입니다.");
-      router.back();
+      router.replace("/map");
       return;
     }
-  }, [status, session, router]);
+  }, [status, session, router, hasUpdated]);
 
   if (
     status === "loading" ||

--- a/app/login/components/LastLoginInfo.tsx
+++ b/app/login/components/LastLoginInfo.tsx
@@ -15,7 +15,7 @@ export default function LastLoginInfo() {
 
   return (
     <div className="flex justify-center">
-      <div className="inline-flex w-fit justify-center gap-2 border rounded-[30px] py-1.5 px-2">
+      <div className="inline-flex w-fit justify-center gap-2 border rounded-[30px] py-1.5 px-4">
         <Image
           src={`/assets/images/social/${provider}.svg`}
           alt="naver"

--- a/app/review/[shareId]/new/page.tsx
+++ b/app/review/[shareId]/new/page.tsx
@@ -4,12 +4,7 @@ import FormDetail from "@/components/common/register/FormDetail";
 import SubHeader from "@/components/common/SubHeader";
 import { Form } from "@/components/ui/form";
 import { useSession } from "next-auth/react";
-import {
-  notFound,
-  useParams,
-  useRouter,
-  useSearchParams,
-} from "next/navigation";
+import { notFound, useParams, useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import useShortReviewOptions from "./hooks/useShortReviewOptions";
 import Loading from "@/components/common/Loading";

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,9 +25,8 @@ export async function middleware(req: NextRequest) {
   if(pathname === "/login" && token){
     return NextResponse.redirect(new URL('/map', req.url));
   }
-
-  // 회원가입 미완료 사용자 처리
-  if (token && !token.publicId && pathname !== "/auth/onboarding") {
+  //회원가입 미완료 사용자 처리
+  if (!isApiRoute && token && !token.publicId && pathname !== "/auth/onboarding" ) {
     return NextResponse.redirect(new URL("/auth/onboarding", req.url));
   }
 


### PR DESCRIPTION
## 📌 이슈 번호

## ✨ 작업 내용
- `/api/auth/session` JSON 파싱 에러로 인해 회원가입 안 되는 오류 수정
  - middleware.ts에서 회원가입 미완료 사용자를 온보딩 페이지로 리다이렉트 시키는 조건 수정

- 회원가입 시 주소 관악구만 가능하도록 수정
- 버튼 클릭 시 비활성화

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
