### PR TITLE
삭제된 게시글 처리 및 폼 미조회 오류 수정

### DIFF
--- a/app/group-buy/[groupBuyId]/edit/page.tsx
+++ b/app/group-buy/[groupBuyId]/edit/page.tsx
@@ -80,12 +80,7 @@ export default function GroupBuyEditPage() {
   });
 
   useEffect(() => {
-    if (
-      !filesLoading &&
-      !detailLoading &&
-      groupBuyFormDetail &&
-      files.length > 0
-    ) {
+    if (!filesLoading && !detailLoading && groupBuyFormDetail) {
       form.reset({
         title: groupBuyFormDetail.title,
         description: groupBuyFormDetail.description,

--- a/application/usecases/group-buy/GetGroupBuyFormDetailUsecase.ts
+++ b/application/usecases/group-buy/GetGroupBuyFormDetailUsecase.ts
@@ -1,35 +1,36 @@
-import type { PrismaGroupBuyRepository } from "@/infra/repositories/prisma/group-buy/PrismaGroupBuyRepository";
+import { HttpError } from "@/errors/HttpError";
 import type { GetGroupBuyFormDetailDto } from "./dto/GetGroupBuyFormDetailDto";
-import { HttpError } from '@/errors/HttpError';
+import type { GroupBuyRepository } from "@/domain/repositories/group-buy/GroupBuyRepository";
+
 
 export class GetGroupBuyFormDetailUsecase {
-  constructor(private groupBuyRepo: PrismaGroupBuyRepository) {}
+  constructor(private groupBuyRepo: GroupBuyRepository) {}
 
   async execute(
     groupBuyId: number,
     userId: string,
   ): Promise<GetGroupBuyFormDetailDto> {
-    const data = await this.groupBuyRepo.getDetail(groupBuyId);
-    
-    if(!data){
+    const data = await this.groupBuyRepo.getFormDetail(groupBuyId);
+
+    if (!data || data.deletedAt) {
       throw new HttpError(404, "존재하지 않는 장보기입니다.");
     }
 
-    if(data.organizerId !== userId){
+    if (data.organizerId !== userId) {
       throw new HttpError(403, "수정 권한이 없습니다.");
     }
 
-    return{
+    return {
       title: data.title ?? "",
-      description: data.desc ?? "",
-      capacity : data.capacity ?? 2,
-      neighborhoodName: data.neighborhoodName ?? "",
-      locationNote : data.locationNote ?? "",
+      description: data.description ?? "",
+      capacity: data.capacity ?? 2,
+      neighborhoodName: data.neighborhood.name ?? "",
+      locationNote: data.locationNote ?? "",
       lat: data.lat ?? 0,
       lng: data.lng ?? 0,
       desiredItem: data.desiredItem ?? "",
       meetingDate: data.meetingDate ?? new Date(),
-      images: data.imageUrls ?? [],
-    }
+      images: data.images.map(img => img.url) ?? [],
+    };
   }
 }

--- a/application/usecases/share/GetShareFormDetailUsecase.ts
+++ b/application/usecases/share/GetShareFormDetailUsecase.ts
@@ -1,33 +1,33 @@
 import { HttpError } from "@/errors/HttpError";
-import type { PrismaShareRepository } from "@/infra/repositories/prisma/share/PrismaShareRepository";
 import type { getShareFormDetailDto } from "./dto/GetShareFormDetailDto";
+import type { ShareRepository } from "@/domain/repositories/share/ShareRepository";
 
 export class GetShareFormDetailUsecase {
-  constructor(private shareRepo: PrismaShareRepository) {}
+  constructor(private shareRepo: ShareRepository) {}
 
   async execute(
     shareId: number,
     userId: string,
   ): Promise<getShareFormDetailDto> {
-    const data = await this.shareRepo.getDetail(shareId);
+    const data = await this.shareRepo.getFormDetail(shareId);
 
-    if (!data) {
+    if (!data || data.deletedAt) {
       throw new HttpError(404, "존재하지 않는 나눔입니다.");
     }
 
-    if (data.organizerId !== userId) {
+    if (data.ownerId !== userId) {
       throw new HttpError(403, "수정 권한이 없습니다.");
     }
 
     return {
-      shareItem: data.desiredItemName ?? "",
+      shareItem: data.shareItem.name ?? "",
       title: data.title ?? "",
-      description: data.desc ?? "",
-      neighborhoodName: data.neighborhoodName ?? "",
+      description: data.description ?? "",
+      neighborhoodName: data.neighborhood.name ?? "",
       locationNote: data.locationNote ?? "",
       lat: data.lat ?? 0,
       lng: data.lng ?? 0,
-      images: data.imageUrls ?? [],
+      images: data.images.map(img => img.url) ?? [],
     };
   }
 }

--- a/domain/repositories/group-buy/GroupBuyRepository.ts
+++ b/domain/repositories/group-buy/GroupBuyRepository.ts
@@ -7,6 +7,22 @@ export interface GetUserGroupbuys {
     itemsPerPage: number,
 }
 
+type GroupBuyFormDetail = Prisma.GroupBuyGetPayload<{
+  include: {
+    images: {
+      select: {
+        url: true;
+      };
+    };
+    neighborhood: {
+      select: {
+        name: true;
+      };
+    };
+  };
+}>;
+
+
 export interface GroupBuyRepository {
   save(groupBuy: Partial<GroupBuy>): Promise<GroupBuy>;
   getUserGroupbuys(shares: GetUserGroupbuys): Promise<(GroupBuy & {participants:number, thumbnailUrl: string})[]>;
@@ -19,4 +35,5 @@ export interface GroupBuyRepository {
   ): Promise<(Partial<GroupBuy> & { thumbnailUrl: string | null, currentUser: number, maxUser: number })[]>;
   softDelete(id: number): Promise<void>;
   update(groupBuy: Partial<GroupBuy>): Promise<GroupBuy>;
+  getFormDetail(groupBuyId: number) : Promise<GroupBuyFormDetail | null>
 }

--- a/domain/repositories/share/ShareRepository.ts
+++ b/domain/repositories/share/ShareRepository.ts
@@ -7,6 +7,26 @@ export interface GetUserShares {
     itemsPerPage: number,
 }
 
+type ShareFormDetail = Prisma.ShareGetPayload<{
+  include: {
+    images : {
+      select : {
+        url: true;
+      }
+    };
+    neighborhood: {
+      select : {
+        name: true
+      }
+    }
+    shareItem : {
+      select : {
+        name: true
+      }
+    }
+  }
+}>
+
 export interface ShareRepository {
   save(share: Partial<Share>): Promise<Share>;
   getUserShares(shares: GetUserShares): Promise<(Share & {thumbnailUrl: string | null})[]>;
@@ -22,4 +42,5 @@ export interface ShareRepository {
   update(share: Partial<Share>): Promise<Share>;
   softDelete(id:number):Promise<void>;
   findRecentShares(userId: string, withinHours: number) : Promise<Share[]>
+  getFormDetail(shareId: number) : Promise<ShareFormDetail | null>
 }

--- a/infra/repositories/prisma/group-buy/PrismaGroupBuyRepository.ts
+++ b/infra/repositories/prisma/group-buy/PrismaGroupBuyRepository.ts
@@ -174,4 +174,23 @@ async getList(
       where: { id: groupBuy.id as number}
     })
   }
+
+  async getFormDetail(groupBuyId: number) {
+    return await this.prisma.groupBuy.findUnique({
+      where : { id: groupBuyId },
+      include : {
+        images: {
+          orderBy: { order: "asc" },
+          select: {
+            url: true,
+          },
+        },
+        neighborhood: {
+          select : {
+            name: true
+          }
+        }
+      }
+    })
+  }
 }

--- a/infra/repositories/prisma/share/PrismaShareRepository.ts
+++ b/infra/repositories/prisma/share/PrismaShareRepository.ts
@@ -158,4 +158,28 @@ export class PrismaShareRepository implements ShareRepository {
       }
     });
   }
+
+  async getFormDetail(shareId : number){
+    return await this.prisma.share.findUnique({
+      where : { id: shareId },
+      include : {
+        images : { 
+          orderBy: { order: "asc" }, 
+          select : { 
+            url: true 
+          }
+        },
+        neighborhood : {
+          select : { 
+            name: true 
+          }
+        },
+        shareItem : {
+          select : {
+            name: true
+          }
+        }
+      }
+    })
+  }
 }

--- a/infra/repositories/prisma/share/PrismaShareRepository.ts
+++ b/infra/repositories/prisma/share/PrismaShareRepository.ts
@@ -154,7 +154,8 @@ export class PrismaShareRepository implements ShareRepository {
     return await this.prisma.share.findMany({
       where:{
         ownerId : userId,
-        createdAt: { gte : threshold}
+        createdAt: { gte : threshold },
+        deletedAt: null
       }
     });
   }


### PR DESCRIPTION
## 📌 이슈 번호

## ✨ 작업 내용
- 같이 장보기 수정 페이지 진입 시 폼 데이터가 채워지지 않던 문제 수정
- 삭제된 나눔/장보기 게시글은 수정 불가능하도록 제한
- 삭제된 나눔의 경우, 24시간 이내 등록되었더라도 등록 페이지에서 항목 선택 가능하도록 수정


## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
