### PR TITLE
수정/등록 페이지 이미지 관련 에러 수정

### DIFF
--- a/application/usecases/group-buy/UpdateGroupBuyUsecase.ts
+++ b/application/usecases/group-buy/UpdateGroupBuyUsecase.ts
@@ -27,6 +27,8 @@ export class UpdateGroupBuyUsecase {
       description : groupBuy.description,
     });
 
+
+
     const images = await Promise.all(
       groupBuy.images.map(async (image, idx) => {
         const imageUrl = await this.imageStorageRepo.uploadPostImage(
@@ -44,6 +46,8 @@ export class UpdateGroupBuyUsecase {
       })
     );
 
-    await this.groupBuyImageRepo.replace(images);
+    
+    if(images.length) await this.groupBuyImageRepo.replace(images);
+    else await this.groupBuyImageRepo.deleteByGroupBuyId(groupBuy.groupBuyId);
   }
 }

--- a/components/common/register/FormMultiImageUpload.tsx
+++ b/components/common/register/FormMultiImageUpload.tsx
@@ -29,22 +29,24 @@ export default function FormMultiImageUpload({
   name,
   rules,
 }: FormMultiImageUploadProps) {
-  const { setValue, trigger, getValues } = useFormContext();
+  const { setValue } = useFormContext();
   const watchedFiles = useWatch({ name });
 
   const [files, setFiles] = useState<File[]>([]);
   const [previews, setPreviews] = useState<string[]>([]);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   // 초기값 설정
   useEffect(() => {
     if (
+      !isInitialized &&
       Array.isArray(watchedFiles) &&
-      watchedFiles.length > 0 &&
-      files.length === 0
+      watchedFiles.length > 0
     ) {
       setFiles(watchedFiles);
+      setIsInitialized(true);
     }
-  }, [watchedFiles, files.length]);
+  }, [watchedFiles, isInitialized]);
 
   // 이미지 미리보기 URL 생성
   useEffect(() => {
@@ -59,9 +61,12 @@ export default function FormMultiImageUpload({
   }, [files]);
 
   useEffect(() => {
-    setValue(name, files, { shouldValidate: false });
-    if (files.length > 0) trigger(name);
-  }, [files, name, setValue, trigger]);
+    if (isInitialized) {
+      setValue(name, files, { shouldValidate: true });
+    } else {
+      setValue(name, files, { shouldValidate: false });
+    }
+  }, [files, name, setValue, isInitialized]);
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;

--- a/domain/repositories/group-buy/GroupBuyImageRepository.ts
+++ b/domain/repositories/group-buy/GroupBuyImageRepository.ts
@@ -4,4 +4,5 @@ export interface GroupBuyImageRepository {
   save(images: Partial<GroupBuyImage>[]): Promise<void>;
   findByGroupBuyId(groupBuyId: number): Promise<GroupBuyImage[]>;
   replace(images: Partial<GroupBuyImage>[]) : Promise<void>;
+  deleteByGroupBuyId(groupBuyId: number) : Promise<void>
 }

--- a/infra/repositories/prisma/group-buy/PrismaGroupBuyImageRepository.ts
+++ b/infra/repositories/prisma/group-buy/PrismaGroupBuyImageRepository.ts
@@ -25,4 +25,8 @@ export class PrismaGroupBuyImageRepository implements GroupBuyImageRepository {
       this.prisma.groupBuyImage.createMany({ data: images }),
     ]);
   }
+
+  async deleteByGroupBuyId(groupBuyId : number) : Promise<void>{
+    await this.prisma.groupBuyImage.deleteMany({ where : { groupBuyId }})
+  }
 }


### PR DESCRIPTION
## 📌 이슈 번호

## ✨ 작업 내용
- 이미지가 1개 남았을 때 X 버튼으로 삭제되지 않던 문제 수정
- 기존에 이미지가 등록되어 있던 장보기 게시글에서 이미지를 모두 삭제한 뒤 수정 시 에러가 발생하던 문제 해결

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
