### PR TITLE
나눔 채팅방 중복참여 현상 수정

### DIFF
--- a/domain/repositories/share/ShareChatRepository.ts
+++ b/domain/repositories/share/ShareChatRepository.ts
@@ -1,5 +1,5 @@
 export interface ShareChatRepository {
-  findChatIdByShareId(postId: number): unknown;
+  findByShareId(postId: number): unknown;
   create(data: { shareId: number }): Promise<{ id: number }>;
   getOwnerId(shareId: number): Promise<string>;
 }

--- a/infra/repositories/prisma/share/PrismaShareChatRepository.ts
+++ b/infra/repositories/prisma/share/PrismaShareChatRepository.ts
@@ -2,22 +2,19 @@ import { PrismaClient } from "@/prisma/generated";
 import type { ShareChatRepository } from "@/domain/repositories/share/ShareChatRepository";
 
 export class PrismaShareChatRepository implements ShareChatRepository {
-  async findChatIdByShareId(shareId: number): Promise<{ id: number } | null> {
-    const chat = await this.prisma.shareChat.findFirst({
-      where: { shareId },
-      select: { id: true },
-    });
-    return chat;
-  }
   private prisma = new PrismaClient();
+
+  async findByShareId(shareId: number) {
+    return this.prisma.shareChat.findMany({
+      where: { shareId },
+      include: { participants: true },
+    });
+  }
 
   async create(data: { shareId: number }): Promise<{ id: number }> {
     const chat = await this.prisma.shareChat.create({
-      data: {
-        shareId: data.shareId,
-      },
+      data: { shareId: data.shareId },
     });
-
     return { id: chat.id };
   }
 
@@ -26,7 +23,6 @@ export class PrismaShareChatRepository implements ShareChatRepository {
       where: { id: shareId },
       select: { ownerId: true },
     });
-
     if (!share?.ownerId) throw new Error("작성자를 찾을 수 없습니다.");
     return share.ownerId;
   }


### PR DESCRIPTION
## 📌 이슈 번호
Closes #159 

## ✨ 작업 내용

- 나눔 상세페이지에서 채팅 참여 시 같은 채팅방으로 참여되던 현상 수정
- 같은 나눔이어도 다른 채팅방(1:1 채팅)으로 신규 개설

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
