### PR TITLE
나눔 상세 페이지 접근 권한 변경 및 스크롤 관련 이슈 수정

### DIFF
--- a/app/group-buy/[groupBuyId]/edit/page.tsx
+++ b/app/group-buy/[groupBuyId]/edit/page.tsx
@@ -151,7 +151,7 @@ export default function GroupBuyEditPage() {
       ) : (
         <>
           <SubHeader titleText="같이 장보기 수정하기" iconType="close" />
-          <section className='"h-[calc(100vh-124px)] py-6 px-4'>
+          <section className="h-[calc(100vh-124px)] py-6 px-4 overflow-auto scrollbar-hide">
             <Form {...form}>
               <form
                 className="flex flex-col gap-4"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,7 +62,7 @@ export default function RootLayout({
 
             <section
               id="scroll-container"
-              className="relative safe-container overflow-auto w-full h-svh mx-auto bg-white sm:border-t sm:border-x sm:border-zinc-300 max-w-[var(--space-mobileMax)]"
+              className="relative safe-container overflow-auto w-full h-svh mx-auto bg-white sm:border-t sm:border-x sm:border-zinc-300 max-w-[var(--space-mobileMax)] scrollbar-hide"
             >
               <main className="md:w-full h-auto">{children}</main>
               <div className="h-auto" id="drawer-customPortal" />

--- a/app/register/group-buy/page.tsx
+++ b/app/register/group-buy/page.tsx
@@ -106,7 +106,7 @@ export default function CreateGroupBuyPage() {
   return (
     <>
       <SubHeader titleText="같이 장보기 등록하기" iconType="close" />
-      <section className="h-[calc(100vh-124px)] py-6 px-4">
+      <section className="h-[calc(100vh-124px)] py-6 px-4 overflow-auto scrollbar-hide">
         <Form {...form}>
           <form
             className="flex flex-col gap-4"

--- a/app/register/share/page.tsx
+++ b/app/register/share/page.tsx
@@ -107,7 +107,7 @@ export default function CreateSharePage() {
       ) : (
         <>
           <SubHeader titleText="나눔 등록하기" iconType="close" />
-          <section className="h-[calc(100vh-124px)] py-6 px-4">
+          <section className="h-[calc(100vh-124px)] py-6 px-4 overflow-auto scrollbar-hide">
             <Form {...form}>
               <form
                 className="flex flex-col gap-4"

--- a/app/review/[shareId]/new/page.tsx
+++ b/app/review/[shareId]/new/page.tsx
@@ -124,7 +124,7 @@ export default function CreateReviewPage() {
         나눔은 어땠나요?`}
             DescSubText="남겨주신 후기는 상대방의 프로필에 공개돼요."
           />
-          <section className="h-[calc(100vh-170px)] py-6 px-4">
+          <section className="h-[calc(100vh-170px)] py-6 px-4 overflow-auto scrollbar-hide">
             <Form {...form}>
               <form
                 className="flex flex-col gap-6"

--- a/app/share/[shareId]/edit/page.tsx
+++ b/app/share/[shareId]/edit/page.tsx
@@ -148,7 +148,7 @@ export default function ShareEditPage() {
       ) : (
         <>
           <SubHeader titleText="나눔 수정하기" iconType="close" />
-          <section className="h-[calc(100vh-124px)] py-6 px-4">
+          <section className="h-[calc(100vh-124px)] py-6 px-4 overflow-auto scrollbar-hide">
             <Form {...form}>
               <form
                 className="flex flex-col gap-4"

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
 
 
-const PUBLIC_PAGE_REGEX = [/^\/group-buy\/\d+$/];
+const PUBLIC_PAGE_REGEX = [/^\/group-buy\/\d+$/, /^\/share\/\d+$/];
 const PUBLIC_PAGE_PATHS = ["/login"];
 const PUBLIC_API_PATHS = [
   "/api/auth",
@@ -19,7 +19,8 @@ export async function middleware(req: NextRequest) {
     PUBLIC_PAGE_REGEX.some((regex) => regex.test(pathname));
   const isPublicApi =
     PUBLIC_API_PATHS.some((path) => pathname.startsWith(path)) ||
-    (/^\/api\/group-buys\/\d+$/.test(pathname) && req.method === "GET");
+    (/^\/api\/group-buys\/\d+$/.test(pathname) && req.method === "GET") ||
+    (/^\/api\/shares\/\d+$/.test(pathname) && req.method === "GET");
   
   const token = await getToken({ req });
   


### PR DESCRIPTION
## 📌 이슈 번호

## ✨ 작업 내용
- 나눔 상세 페이지 로그인 안 한 유저도 접근 가능
- 스크롤바 숨김
- 스크롤 시 컨텐츠가 푸터 아래로 넘어가지 않도록 수정

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
