### PR TITLE
나눔 채팅에서 예약, 종료 권한 및 예약날짜 볼 수 있는 유저 제한

### DIFF
--- a/app/api/chat/[chatId]/shares/complete/route.ts
+++ b/app/api/chat/[chatId]/shares/complete/route.ts
@@ -7,6 +7,7 @@ export async function PATCH(
   { params }: { params: Promise<{ chatId: string }> }
 ) {
   const { chatId } = await params;
+  const { myUserId } = await req.json();
 
   try {
     const repository = new PrismaUpdateShareStatusRepository();
@@ -14,14 +15,15 @@ export async function PATCH(
 
     await useCase.execute({
       chatId: Number(chatId),
+      myUserId,
       status: 2,
     });
 
     await fetch("https://port-0-sik-share-server-m61t9knhb5c1f236.sel4.cloudtype.app/api/share-complete-message", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ chatId }),
-  });
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chatId }),
+    });
 
     return NextResponse.json({ message: "success" }, { status: 200 });
   } catch (e) {

--- a/app/api/chat/[chatId]/shares/route.ts
+++ b/app/api/chat/[chatId]/shares/route.ts
@@ -5,6 +5,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 import { PrismaChatMessageRepository } from "@/infra/repositories/prisma/PrismaChatMessageListRepository";
 import { GetShareChatListUsecase } from "@/application/usecases/chat/GetShareChatListUsecase";
+import { PrismaUpdateMeetingDateRepository } from "@/infra/repositories/prisma/PrismaUpdateMeetingDateRepository";
 
 export async function GET(
   req: NextRequest,
@@ -28,5 +29,25 @@ export async function GET(
     return NextResponse.json(chatDetail);
   } catch (err) {
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ chatId: string }> }
+) {
+  const { chatId } = await params;
+  const { meetingDate, myUserId } = await req.json();
+
+  try {
+    const repository = new PrismaUpdateMeetingDateRepository();
+    await repository.updateMeetingDate(Number(chatId), new Date(meetingDate), myUserId);
+
+    return NextResponse.json({ message: "success" }, { status: 200 });
+  } catch (e) {
+    return NextResponse.json(
+      { message: (e as Error).message },
+      { status: 500 },
+    );
   }
 }

--- a/app/chat/components/ChatRoom.tsx
+++ b/app/chat/components/ChatRoom.tsx
@@ -51,6 +51,8 @@ interface ChatRoomProps {
     imageUrl: string[] | [];
     meetingDate?: string;
     status?: number;
+    ownerId: string;
+    recipientId: string | null;
   };
   togetherInfo?: TogetherInfoProps;
   senderId: string;

--- a/app/share-box/[publicId]/page.tsx
+++ b/app/share-box/[publicId]/page.tsx
@@ -87,7 +87,6 @@ export default function ShareBoxPage() {
       .then((res) => res.json())
       .then((data) => {
         setShareList(data);
-        console.log("Share List Data:", data);
       });
   }, [publicId]);
 

--- a/application/usecases/chat/UpdateMeetingDateUseCase.ts
+++ b/application/usecases/chat/UpdateMeetingDateUseCase.ts
@@ -8,7 +8,7 @@ export class UpdateMeetingDateUseCase {
     await this.shareChatRepository.updateMeetingDate(
       dto.chatId,
       dto.meetingDate,
-      dto.status,
+      dto.myUserId,
     );
   }
 }

--- a/application/usecases/chat/UpdateShareStatusUseCase.ts
+++ b/application/usecases/chat/UpdateShareStatusUseCase.ts
@@ -7,6 +7,7 @@ export class UpdateShareStatusUseCase {
   async execute(dto: UpdateShareStatusDto): Promise<void> {
     await this.shareChatRepository.updateShareStatus(
       dto.chatId
+      ,dto.myUserId,
     );
   }
 }

--- a/application/usecases/chat/dto/ChatMessageListDto.ts
+++ b/application/usecases/chat/dto/ChatMessageListDto.ts
@@ -10,5 +10,7 @@ export class ChatMessageListDto {
     public time: string,
     public readCount?: number,
     public senderId?: string, 
+    public onwerId?: string,
+    public recipientId?: string | null,
   ) {}
 }

--- a/application/usecases/chat/dto/UpdateMeetingDateDto.ts
+++ b/application/usecases/chat/dto/UpdateMeetingDateDto.ts
@@ -2,6 +2,6 @@ export class UpdateMeetingDateDto {
   constructor(    
     public chatId: number,
     public meetingDate: Date,
-    public status: number,
+    public myUserId: string,
     ){}
 }

--- a/application/usecases/chat/dto/UpdateShareStatusDto.ts
+++ b/application/usecases/chat/dto/UpdateShareStatusDto.ts
@@ -2,5 +2,6 @@ export class UpdateShareStatusDto {
   constructor(    
     public chatId: number,
     public status: number,
+    public myUserId: string,
     ){}
 }

--- a/domain/repositories/chat/ChatMessageListRepository.ts
+++ b/domain/repositories/chat/ChatMessageListRepository.ts
@@ -23,5 +23,7 @@ export interface ChatMessageRepository {
     locationNote: string;
     meetingDate?: string;
     status: number;
+    ownerId: string;
+    recipientId: string | null;
   }>;
 }

--- a/domain/repositories/chat/UpdateMeetingDateRepository.ts
+++ b/domain/repositories/chat/UpdateMeetingDateRepository.ts
@@ -1,3 +1,3 @@
 export interface UpdateMeetingDateRepository {
-  updateMeetingDate(chatId: number, meetingDate: Date, status?: number): Promise<void>;
+  updateMeetingDate(chatId: number, meetingDate: Date, myUserId: string): Promise<void>;
 }

--- a/domain/repositories/chat/UpdateShareStatusRepository.ts
+++ b/domain/repositories/chat/UpdateShareStatusRepository.ts
@@ -1,3 +1,3 @@
 export interface UpdateShareStatusRepository {
-  updateShareStatus(chatId: number): Promise<void>;
+  updateShareStatus(chatId: number, myUserId: string): Promise<void>;
 }

--- a/infra/repositories/prisma/PrismaChatMessageListRepository.ts
+++ b/infra/repositories/prisma/PrismaChatMessageListRepository.ts
@@ -88,6 +88,8 @@ return messages.map((msg) => {
   locationNote: string;
   meetingDate?: string;
   status: number;
+  ownerId: string;
+  recipientId: string | null;
 }> {
   const shareChat = await prisma.shareChat.findUnique({
     where: { id: chatId },
@@ -107,6 +109,8 @@ return messages.map((msg) => {
       locationNote: true,
       meetingDate: true,
       status: true,
+      ownerId: true,
+      recipientId: true,
     },
   });
 
@@ -130,6 +134,8 @@ return messages.map((msg) => {
     imageUrl,
     meetingDate: share.meetingDate ? share.meetingDate.toISOString() : undefined,
     status: share.status,
+    ownerId: share.ownerId,
+    recipientId: share.recipientId,
   };
 }
 }

--- a/infra/repositories/prisma/PrismaUpdateMeetingDateRepository.ts
+++ b/infra/repositories/prisma/PrismaUpdateMeetingDateRepository.ts
@@ -4,7 +4,7 @@ import type { UpdateMeetingDateRepository } from "@/domain/repositories/chat/Upd
 const prisma = new PrismaClient();
 
 export class PrismaUpdateMeetingDateRepository implements UpdateMeetingDateRepository {
-  async updateMeetingDate(chatId: number, meetingDate: Date): Promise<void> {
+  async updateMeetingDate(chatId: number, meetingDate: Date, myUserId: string): Promise<void> {
     const chat = await prisma.shareChat.findUnique({
       where: { id: chatId },
       select: { shareId: true },
@@ -14,9 +14,26 @@ export class PrismaUpdateMeetingDateRepository implements UpdateMeetingDateRepos
       throw new Error("해당 채팅의 나눔 정보를 찾을 수 없습니다.");
     }
 
+    const otherParticipant = await prisma.shareChatParticipant.findFirst({
+      where: {
+        shareChatId: chatId,
+        userId: { not: myUserId }
+      },
+      select: { userId: true }
+    });
+
+    if (!otherParticipant) {
+      throw new Error("나 이외의 참여자를 찾을 수 없습니다.");
+    }
+
     await prisma.share.update({
       where: { id: chat.shareId },
-      data: { meetingDate, status: 1 },
+      data: {
+        meetingDate,
+        status: 1,
+        recipientId: otherParticipant.userId,
+      },
     });
   }
 }
+

--- a/infra/repositories/prisma/PrismaUpdateShareStatusRepository.ts
+++ b/infra/repositories/prisma/PrismaUpdateShareStatusRepository.ts
@@ -4,7 +4,7 @@ import type { UpdateShareStatusRepository } from "@/domain/repositories/chat/Upd
 const prisma = new PrismaClient();
 
 export class PrismaUpdateShareStatusRepository implements UpdateShareStatusRepository {
-  async updateShareStatus(chatId: number): Promise<void> {
+  async updateShareStatus(chatId: number, myUserId: string): Promise<void> {
     const chat = await prisma.shareChat.findUnique({
       where: { id: chatId },
       select: { shareId: true },
@@ -13,10 +13,22 @@ export class PrismaUpdateShareStatusRepository implements UpdateShareStatusRepos
     if (!chat?.shareId) {
       throw new Error("해당 채팅의 나눔 정보를 찾을 수 없습니다.");
     }
+    
+    const otherParticipant = await prisma.shareChatParticipant.findFirst({
+      where: {
+        shareChatId: chatId,
+        userId: { not: myUserId }
+      },
+      select: { userId: true }
+    });
+
+    if (!otherParticipant) {
+      throw new Error("나 이외의 참여자를 찾을 수 없습니다.");
+    }
 
     await prisma.share.update({
       where: { id: chat.shareId },
-      data: { status: 2 },
+      data: { status: 2, recipientId: otherParticipant.userId }
     });
   }
 }


### PR DESCRIPTION
## ✨ 작업 내용

- 나눔채팅에서 예약하기, 완료하기 버튼을 볼 수 있는 사람은 나눔글을 발행한 사람으로 한정했습니다.
  - 또한, 예약하기를 눌렀을 때 예약 날짜를 볼 수 있는 사람은 예약자와 나눔글 발행자 두 사람만 볼 수 있도록 했습니다.
  - 나눔글의 상태값을 변경할때 예약자 ID를 넣어주도록 수정했습니다.

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
