### PR TITLE
fix: 삭제된 채팅방 헤더 조건 추가

### DIFF
--- a/app/chat/[chatId]/shares/page.tsx
+++ b/app/chat/[chatId]/shares/page.tsx
@@ -39,6 +39,7 @@ interface ShareInfo {
   imageUrl: string[];
   ownerId: string;
   recipientId: string | null;
+  deltedAt?: Date | null;
 }
 
 export default function ShareChat() {

--- a/app/chat/[chatId]/together/page.tsx
+++ b/app/chat/[chatId]/together/page.tsx
@@ -12,6 +12,7 @@ interface TogetherInfo {
   participantCount?: number;
   status: number;
   senderId?: string;
+  deletedAt?: Date | null;
 }
 
 export default function TogetherChat() {
@@ -61,6 +62,7 @@ export default function TogetherChat() {
         meetingDate: info.meetingDate,
         participantCount: info.participantCount,
         status: info.status,
+        deletedAt: info.deletedAt || null,
       }}
       senderId={info.senderId || ""}
     />

--- a/app/chat/components/ChatHeader.tsx
+++ b/app/chat/components/ChatHeader.tsx
@@ -48,7 +48,7 @@ export default function ChatHeader(props: ChatHeaderProps) {
       )}
       {props.type === "together" && (
         <div className="flex flex-col items-center justify-center h-[38px] flex-1 min-w-0">
-          <span className="body-md truncate w-[227px] block">
+          <span className="body-md truncate text-center w-[227px] block">
             {props.title}
           </span>
           <div className="flex items-center justify-center gap-[2px]">

--- a/app/chat/components/ChatRoom.tsx
+++ b/app/chat/components/ChatRoom.tsx
@@ -33,6 +33,7 @@ interface TogetherInfoProps {
   meetingDate?: string;
   participantCount?: number;
   status: number;
+  deletedAt?: Date | null;
 }
 
 interface ChatRoomProps {
@@ -205,6 +206,7 @@ export default function ChatRoom({
           meetingDate={togetherInfo.meetingDate}
           locationNote={togetherInfo.locationNote}
           status={togetherInfo.status}
+          deletedAt={togetherInfo.deletedAt}
         />
       )}
       {type === "share" && shareInfo && (

--- a/app/chat/components/ShareInfo.tsx
+++ b/app/chat/components/ShareInfo.tsx
@@ -27,6 +27,7 @@ interface ShareInfoProps {
     status: number;
     ownerId: string;
     recipientId: string | null;
+    deletedAt?: Date | null;
   };
   onMeetingDateChange?: (date: Date) => void;
 }
@@ -181,6 +182,34 @@ export default function ShareInfo({
       >
         나눔완료
       </Badge>
+    );
+  }
+
+  if (info.deletedAt) {
+    return (
+      <div className="flex flex-col gap-3 px-4 py-2 border-b opacity-30">
+        <div className="flex w-full items-center gap-2">
+          <Image
+            src={info.imageUrl[0] || "/assets/images/example/thumbnail.png"}
+            width={48}
+            height={48}
+            className="rounded-sm w-[48px] h-[48px] object-full"
+            alt="shareImage"
+          />
+          <div className="flex flex-col flex-1 min-w-0">
+            <div className="flex gap-2 text-center items-center">
+              <p className="body-md">삭제됨</p>
+              <p className="body-md truncate !font-light">{info.title}</p>
+            </div>
+            <div className="flex flex-row text-caption gap-[2px]">
+              <MapPin className="w-4 h-4" />
+              <p className="text-xs text-zinc-500 truncate">
+                {info.locationNote}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
     );
   }
 

--- a/app/chat/components/TogetherInfo.tsx
+++ b/app/chat/components/TogetherInfo.tsx
@@ -20,6 +20,7 @@ interface TogetherInfoProps {
   meetingDate?: string;
   locationNote?: string;
   status: number;
+  deletedAt?: Date | null;
 }
 
 export default function TogetherInfo({
@@ -29,9 +30,20 @@ export default function TogetherInfo({
   meetingDate,
   locationNote,
   status: initialStatus,
+  deletedAt,
 }: TogetherInfoProps) {
   const [status, setStatus] = useState<number>(initialStatus);
   const [open, setOpen] = useState(false);
+
+  console.log("TogetherInfo", {
+    chatId,
+    title,
+    imageUrl,
+    meetingDate,
+    locationNote,
+    status: initialStatus,
+    deletedAt,
+  });
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -66,6 +78,50 @@ export default function TogetherInfo({
     }
     return "";
   }
+
+  if (deletedAt) {
+    return (
+      <div className="flex h-[99px] items-start gap-3 px-4 py-2 border-b opacity-30">
+        <div className="flex-shrink-0">
+          <Image
+            src={
+              getImageUrl(imageUrl)?.startsWith("http")
+                ? getImageUrl(imageUrl)
+                : "/assets/images/example/thumbnail.png"
+            }
+            width={64}
+            height={64}
+            alt="장보기 이미지"
+            className="rounded-md"
+          />
+        </div>
+        <div className="flex flex-col justify-center min-w-0 itmes-center">
+          <div className="flex gap-2 text-center items-center">
+            <p className="body-md">삭제됨</p>
+            <p className="body-md truncate !font-light">{title}</p>
+          </div>
+          <div className="flex items-center caption text-zinc-500 gap-5">
+            <div className="flex items-center gap-1">
+              <Clock className="w-4 h-4" />
+              <span>
+                {meetingDate
+                  ? new Date(meetingDate).toLocaleString("ko-KR", {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    })
+                  : "미정"}
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              <MapPin className="w-4 h-4" />
+              <span>{locationNote ?? "장소 미정"}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-start gap-3 px-4 py-2 border-b">
       <div className="flex-shrink-0">

--- a/application/usecases/chat/dto/ChatDetailDto.ts
+++ b/application/usecases/chat/dto/ChatDetailDto.ts
@@ -14,6 +14,7 @@ export class ChatDetailDto {
       locationNote: string;
       meetingDate?: string;
       status: number;
+      ownerId: string;
     }
   ) {}
 }

--- a/domain/repositories/chat/ChatMessageListRepository.ts
+++ b/domain/repositories/chat/ChatMessageListRepository.ts
@@ -25,5 +25,6 @@ export interface ChatMessageRepository {
     status: number;
     ownerId: string;
     recipientId: string | null;
+    deletedAt: Date | null;
   }>;
 }

--- a/domain/repositories/chat/GroupBuyChatMessageRepository.ts
+++ b/domain/repositories/chat/GroupBuyChatMessageRepository.ts
@@ -13,5 +13,6 @@ export interface GroupBuyChatMessageRepository {
     imageUrl: string;
     participantCount: number;
     status: number;
+    deletedAt?: Date | null;
   }>;
 }

--- a/infra/repositories/prisma/PrismaChatMessageListRepository.ts
+++ b/infra/repositories/prisma/PrismaChatMessageListRepository.ts
@@ -91,6 +91,7 @@ return messages.map((msg) => {
   status: number;
   ownerId: string;
   recipientId: string | null;
+  deletedAt: Date | null;
 }> {
   const shareChat = await prisma.shareChat.findUnique({
     where: { id: chatId },
@@ -113,6 +114,7 @@ return messages.map((msg) => {
       status: true,
       ownerId: true,
       recipientId: true,
+      deletedAt: true,
     },
   });
 
@@ -139,6 +141,7 @@ return messages.map((msg) => {
     status: share.status,
     ownerId: share.ownerId,
     recipientId: share.recipientId,
+    deletedAt: share.deletedAt,
   };
 }
 }

--- a/infra/repositories/prisma/PrismaGroupBuyChatMessageRepository.ts
+++ b/infra/repositories/prisma/PrismaGroupBuyChatMessageRepository.ts
@@ -37,6 +37,7 @@ export class PrismaGroupBuyChatMessageRepository implements GroupBuyChatMessageR
     participantCount: number;
     locationNote: string;
     status: number;
+    deletedAt?: Date | null;
   }> {
     const chat = await prisma.groupBuyChat.findUnique({
       where: { id: chatId },
@@ -61,6 +62,7 @@ export class PrismaGroupBuyChatMessageRepository implements GroupBuyChatMessageR
       participantCount: chat.participants.length,
       locationNote: groupBuy.locationNote,
       status: groupBuy.status,
+      deletedAt: groupBuy.deletedAt,
     };
   }
 }


### PR DESCRIPTION
## ✨ 작업 내용

- 삭제된 게시글은, 채팅방에서 헤더가 다르게 보이도록 수정했습니다.

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

<img width="429" alt="스크린샷 2025-06-04 오후 3 39 19" src="https://github.com/user-attachments/assets/59a3b14f-7007-4a0c-8d4f-1bcee8d43b2d" />
<img width="431" alt="스크린샷 2025-06-04 오후 4 12 04" src="https://github.com/user-attachments/assets/adda4d15-ac7d-4240-9d58-4e6acf26a6ca" />


## 💬 기타 참고 사항
