### PR TITLE
각종 에러 수정 및 스타일 수정

### DIFF
--- a/app/chat/components/ChatHeader.tsx
+++ b/app/chat/components/ChatHeader.tsx
@@ -53,7 +53,9 @@ export default function ChatHeader(props: ChatHeaderProps) {
           </span>
           <div className="flex items-center justify-center gap-[2px]">
             <UsersRound className="w-4 h-4" />
-            <span className="badge-medium">{props.participantCount}</span>
+            <span className="label color zinc-500">
+              {props.participantCount}
+            </span>
           </div>
         </div>
       )}

--- a/app/chat/components/ChatHeader.tsx
+++ b/app/chat/components/ChatHeader.tsx
@@ -52,8 +52,8 @@ export default function ChatHeader(props: ChatHeaderProps) {
             {props.title}
           </span>
           <div className="flex items-center justify-center gap-[2px]">
-            <UsersRound className="w-4 h-4" />
-            <span className="label color zinc-500">
+           <UsersRound className="w-4 h-4" strokeWidth={1} />
+            <span className="label text-zinc-500">
               {props.participantCount}
             </span>
           </div>

--- a/app/chat/components/ChatList.tsx
+++ b/app/chat/components/ChatList.tsx
@@ -85,11 +85,11 @@ export default function ChatList({
             </>
           )}
         </div>
-        <div className="flex flex-col">
+        <div className="flex flex-col max-w-[300px]">
           <div className="flex items-center gap-1">
             {type === "together" && (
               <>
-                <p className="body-md w-[180px] overflow-hidden text-ellipsis whitespace-nowrap">
+                <p className="body-md max-w-[180px] overflow-hidden text-ellipsis whitespace-nowrap">
                   {groupBuyTitle}
                 </p>
                 <div className="flex flex-row gap-[2px]">
@@ -110,7 +110,7 @@ export default function ChatList({
                 : ""}
             </p>
           </div>
-          <p className="caption !text-zinc-500">{lastMessage}</p>
+          <p className="caption !text-zinc-500 truncate">{lastMessage}</p>
         </div>
       </div>
       {unreadCount > 0 && (

--- a/app/chat/components/ChatMessage.tsx
+++ b/app/chat/components/ChatMessage.tsx
@@ -48,11 +48,11 @@ export default function ChatMessage({
           />
           <div className="flex flex-col">
             <div className="body-sm mb-3">{nickname}</div>
-            <div className="flex items-center gap-1">
+            <div className="flex items-end gap-1">
               <div className="mb-1 bg-zinc-200 body-sm rounded-[25px] rounded-tl-none px-4 py-3 max-w-[220px] break-words">
                 {message}
               </div>
-              <div className="flex flex-col items-start justify-center">
+              <div className="flex flex-col items-end justify-end">
                 {displayCount !== null && (
                   <div className="label text-primary">{displayCount}</div>
                 )}

--- a/app/chat/components/ChatMessageList.tsx
+++ b/app/chat/components/ChatMessageList.tsx
@@ -38,7 +38,7 @@ export default function ChatMessageList({
   return (
     <div
       ref={scrollRef}
-      className="w-full px-4 py-4 flex flex-col gap-4 h-[calc(100vh-240px)] overflow-y-scroll"
+      className="w-full px-4 py-4 flex flex-col gap-4 h-full overflow-y-scroll"
     >
       {messages.map((msg, index) => (
         <ChatMessage

--- a/app/chat/components/ChatRoom.tsx
+++ b/app/chat/components/ChatRoom.tsx
@@ -188,7 +188,7 @@ export default function ChatRoom({
     : [];
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-svh">
       {type === "together" && togetherInfo ? (
         <ChatHeader
           type="together"

--- a/app/chat/components/ShareInfo.tsx
+++ b/app/chat/components/ShareInfo.tsx
@@ -224,7 +224,7 @@ export default function ShareInfo({
             src={info.imageUrl[0] || "/assets/images/example/thumbnail.png"}
             width={48}
             height={48}
-            className="rounded-sm w-[48px] h-[48px] object-full"
+            className="rounded-sm w-[48px] h-[48px] object-full border border-zinc-100"
             alt="shareImage"
           />
           <div className="flex flex-col flex-1 min-w-0">

--- a/app/chat/components/ShareInfo.tsx
+++ b/app/chat/components/ShareInfo.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import Image from "next/image";
-import { InfoIcon, MapPin } from "lucide-react";
+import { Clock4Icon, MapPin } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -215,10 +215,10 @@ export default function ShareInfo({
 
   return (
     <div className="flex flex-col gap-3 px-4 py-2 border-b">
-      <div className="flex w-full items-center gap-2">
+      <div className="flex w-full items-start gap-2">
         <Link
           href={`/share/${info.id}`}
-          className="flex items-center gap-2 flex-1 min-w-0"
+          className="flex items-center gap-2 flex-1 min-w-0 cursor-pointer"
         >
           <Image
             src={info.imageUrl[0] || "/assets/images/example/thumbnail.png"}
@@ -228,7 +228,7 @@ export default function ShareInfo({
             alt="shareImage"
           />
           <div className="flex flex-col flex-1 min-w-0">
-            <p className="body-md truncate">{info.title}</p>
+            <p className="body-md truncate mb-[5px]">{info.title}</p>
             <div className="flex flex-row text-caption gap-[2px]">
               <MapPin className="w-4 h-4" />
               <p className="text-xs text-zinc-500 truncate">
@@ -245,7 +245,7 @@ export default function ShareInfo({
             variant="reserve"
             className="text-white flex items-center gap-2"
           >
-            <InfoIcon />
+            <Clock4Icon />
             <p>{formatDate(reservedDate)}</p>
           </Badge>
         )}

--- a/app/chat/components/TogetherInfo.tsx
+++ b/app/chat/components/TogetherInfo.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { MapPin, Clock } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import dayjs from "dayjs";
 import {
   Dialog,
   DialogTrigger,
@@ -34,16 +35,6 @@ export default function TogetherInfo({
 }: TogetherInfoProps) {
   const [status, setStatus] = useState<number>(initialStatus);
   const [open, setOpen] = useState(false);
-
-  console.log("TogetherInfo", {
-    chatId,
-    title,
-    imageUrl,
-    meetingDate,
-    locationNote,
-    status: initialStatus,
-    deletedAt,
-  });
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
@@ -138,17 +129,12 @@ export default function TogetherInfo({
         />
       </div>
       <div className="flex flex-col flex-1 min-w-0 self-center">
-        <p className="badge-md truncate">{title}</p>
+        <p className="body-md truncate mb-[5px]">{title}</p>
         <div className="flex items-center caption text-zinc-500 gap-5">
           <div className="flex items-center gap-1">
             <Clock className="w-4 h-4" />
             <span>
-              {meetingDate
-                ? new Date(meetingDate).toLocaleString("ko-KR", {
-                    dateStyle: "medium",
-                    timeStyle: "short",
-                  })
-                : "미정"}
+              {meetingDate ? dayjs(meetingDate).format("YYYY-MM-DD") : "미정"}
             </span>
           </div>
           <div className="flex items-center gap-1">
@@ -157,7 +143,7 @@ export default function TogetherInfo({
           </div>
         </div>
       </div>
-      <div className="self-center">
+      <div>
         {status === 2 ? (
           <Badge
             variant="reserve"

--- a/app/chat/components/TogetherInfo.tsx
+++ b/app/chat/components/TogetherInfo.tsx
@@ -125,7 +125,7 @@ export default function TogetherInfo({
           width={64}
           height={64}
           alt="장보기 이미지"
-          className="rounded-md"
+          className="rounded-md border border-zinc-100"
         />
       </div>
       <div className="flex flex-col flex-1 min-w-0 self-center">

--- a/app/map/components/MapList.tsx
+++ b/app/map/components/MapList.tsx
@@ -145,7 +145,7 @@ export function MapList({ selectedId }: MapListProps) {
   });
 
   return (
-    <div className="max-h-[55vh] min-h-[55vh] overflow-y-auto border-t-1">
+    <div className="overflow-y-auto border-t-1">
       {items.map((item, i) => (
         <Link
           href={`/${item.type === "groupbuy" ? "group-buy" : "share"}/${item.id}`}


### PR DESCRIPTION
## ✨ 작업 내용

- 메세지가 길 경우, 채팅방 목록에서 ... 으로 나오게 수정했습니다.
- ShareInfo에서 예약된 날짜 아이콘을 수정했습니다.
- MapList의 max-h-[55vh] min-h-[55vh]를 삭제했습니다.
- groupbuyTitle 부분에 max-width를 설정했습니다.
- TogetherInfo에 날짜를 YYYY-MM-DD로 수정했습니다.
- 상대방 메세지 읽음 카운트를 메세지 가운데가 아닌 아래에서 보도록 수정했습니다.
- ShareInfo 눌러서 디테일 페이지로 가는부분에 cursor: pointer 추가했습니다.
- 각종 마진을 추가 했습니다.
- ShareInfo, TogetherInfo에 이미지에 border를 추가했습니다.
- ShareInfo의 MapPin에 color를 설정했습니다.

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련된 테스트를 추가하거나 수정했습니다.
- [ ] 문서화가 필요한 경우 문서를 업데이트했습니다.

## 📸 스크린샷(선택)

## 💬 기타 참고 사항
